### PR TITLE
Output test execution time

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ function test(err, title, duration) {
 	var threshold = 100;
 
 	if (duration > threshold) {
-		var formattedDuration = prettyMs(duration, { secDecimalDigits: 2 });
+		var formattedDuration = prettyMs(duration, {
+			secDecimalDigits: 2
+		});
 
 		timeSpent = chalk.gray.dim(' (' + formattedDuration + ')');
 	}

--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ function test(err, title, duration) {
 	var threshold = 100;
 
 	if (duration > threshold) {
-		timeSpent = chalk.gray.dim(' (' + prettyMs(duration) + ')');
+		var formattedDuration = prettyMs(duration, { secDecimalDigits: 2 });
+
+		timeSpent = chalk.gray.dim(' (' + formattedDuration + ')');
 	}
 
 	log.success(title + timeSpent);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function test(err, title, duration) {
 		return;
 	}
 
-	log.success(title + ' (' + hrtime(duration) + ')');
+	log.success(title + ' ' + chalk.dim('(' + hrtime(duration) + ')'));
 }
 
 function stack(results) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var hrtime = require('pretty-hrtime');
+var prettyMs = require('pretty-ms');
 var chalk = require('chalk');
 var figures = require('figures');
 var Squeak = require('squeak');
@@ -24,7 +24,7 @@ function test(err, title, duration) {
 		return;
 	}
 
-	log.success(title + ' ' + chalk.dim('(' + hrtime(duration) + ')'));
+	log.success(title + ' ' + chalk.dim('(' + prettyMs(duration) + ')'));
 }
 
 function stack(results) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var hrtime = require('pretty-hrtime');
 var chalk = require('chalk');
 var figures = require('figures');
 var Squeak = require('squeak');
@@ -17,13 +18,13 @@ log.type('error', {
 	prefix: figures.cross
 });
 
-function test(err, title) {
+function test(err, title, duration) {
 	if (err) {
 		log.error(title, chalk.red(err.message));
 		return;
 	}
 
-	log.success(title);
+	log.success(title + ' (' + hrtime(duration) + ')');
 }
 
 function stack(results) {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,17 @@ function test(err, title, duration) {
 		return;
 	}
 
-	log.success(title + ' ' + chalk.dim('(' + prettyMs(duration) + ')'));
+	// format a time spent in the test
+	var timeSpent = '';
+
+	// display duration only over a threshold
+	var threshold = 100;
+
+	if (duration > threshold) {
+		timeSpent = chalk.dim('(' + prettyMs(duration) + ')');
+	}
+
+	log.success(title + ' ' + timeSpent);
 }
 
 function stack(results) {

--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@ function test(err, title, duration) {
 	var threshold = 100;
 
 	if (duration > threshold) {
-		timeSpent = chalk.dim('(' + prettyMs(duration) + ')');
+		timeSpent = chalk.gray.dim(' (' + prettyMs(duration) + ')');
 	}
 
-	log.success(title + ' ' + timeSpent);
+	log.success(title + timeSpent);
 }
 
 function stack(results) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -36,17 +36,18 @@ Runner.prototype.addSerialTest = function (title, cb) {
 
 Runner.prototype.concurrent = function (cb) {
 	each(this.tests.concurrent, function (test, i, next) {
-		test.run(function (err) {
+		test.run(function (err, duration) {
 			if (err) {
 				this.stats.failCount++;
 			}
 
 			this.results.push({
+				duration: duration,
 				title: test.title,
 				error: err
 			});
 
-			this.emit('test', err, test.title);
+			this.emit('test', err, test.title, duration);
 			next();
 		}.bind(this));
 	}.bind(this), cb);
@@ -54,17 +55,18 @@ Runner.prototype.concurrent = function (cb) {
 
 Runner.prototype.serial = function (cb) {
 	eachSerial(this.tests.serial, function (test, next) {
-		test.run(function (err) {
+		test.run(function (err, duration) {
 			if (err) {
 				this.stats.failCount++;
 			}
 
 			this.results.push({
+				duration: duration,
 				title: test.title,
 				error: err
 			});
 
-			this.emit('test', err, test.title);
+			this.emit('test', err, test.title, duration);
 			next();
 		}.bind(this));
 	}.bind(this), cb);

--- a/lib/test.js
+++ b/lib/test.js
@@ -21,6 +21,12 @@ function Test(title, fn) {
 	this.fn = fn;
 	this.assertCount = 0;
 	this.planCount = null;
+
+	// store the time point
+	// before test execution
+	// to pass it to process.hrtime()
+	// and calculate the total time spent in test
+	this._timeStart = 0;
 }
 
 util.inherits(Test, EventEmitter);
@@ -67,6 +73,8 @@ Test.prototype.run = function (cb) {
 		this.exit();
 	}
 
+	this._timeStart = process.hrtime();
+
 	try {
 		var ret = this.fn(this);
 
@@ -98,6 +106,9 @@ Test.prototype.end = function () {
 };
 
 Test.prototype.exit = function () {
+	// calculate total time spent in test
+	var duration = process.hrtime(this._timeStart);
+
 	if (this.planCount !== null && this.planCount !== this.assertCount) {
 		this.assertError = new assert.AssertionError({
 			actual: this.assertCount,
@@ -113,7 +124,7 @@ Test.prototype.exit = function () {
 		this.ended = true;
 
 		setImmediate(function () {
-			this.cb(this.assertError);
+			this.cb(this.assertError, duration);
 		}.bind(this));
 	}
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -24,8 +24,7 @@ function Test(title, fn) {
 
 	// store the time point
 	// before test execution
-	// to pass it to process.hrtime()
-	// and calculate the total time spent in test
+	// to calculate the total time spent in test
 	this._timeStart = 0;
 }
 
@@ -73,7 +72,7 @@ Test.prototype.run = function (cb) {
 		this.exit();
 	}
 
-	this._timeStart = process.hrtime();
+	this._timeStart = Date.now();
 
 	try {
 		var ret = this.fn(this);
@@ -107,7 +106,7 @@ Test.prototype.end = function () {
 
 Test.prototype.exit = function () {
 	// calculate total time spent in test
-	var duration = process.hrtime(this._timeStart);
+	var duration = Date.now() - this._timeStart;
 
 	if (this.planCount !== null && this.planCount !== this.assertCount) {
 		this.assertError = new assert.AssertionError({

--- a/lib/test.js
+++ b/lib/test.js
@@ -21,11 +21,12 @@ function Test(title, fn) {
 	this.fn = fn;
 	this.assertCount = 0;
 	this.planCount = null;
+	this.duration = null;
 
 	// store the time point
 	// before test execution
 	// to calculate the total time spent in test
-	this._timeStart = 0;
+	this._timeStart = null;
 }
 
 util.inherits(Test, EventEmitter);
@@ -106,7 +107,7 @@ Test.prototype.end = function () {
 
 Test.prototype.exit = function () {
 	// calculate total time spent in test
-	var duration = Date.now() - this._timeStart;
+	this.duration = Date.now() - this._timeStart;
 
 	if (this.planCount !== null && this.planCount !== this.assertCount) {
 		this.assertError = new assert.AssertionError({
@@ -123,7 +124,7 @@ Test.prototype.exit = function () {
 		this.ended = true;
 
 		setImmediate(function () {
-			this.cb(this.assertError, duration);
+			this.cb(this.assertError, this.duration);
 		}.bind(this));
 	}
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "globby": "^2.0.0",
     "meow": "^3.3.0",
     "plur": "^2.0.0",
-    "pretty-hrtime": "^1.0.0",
+    "pretty-ms": "^2.0.0",
     "squeak": "^1.2.0",
     "update-notifier": "^0.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "globby": "^2.0.0",
     "meow": "^3.3.0",
     "plur": "^2.0.0",
+    "pretty-hrtime": "^1.0.0",
     "squeak": "^1.2.0",
     "update-notifier": "^0.5.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -343,3 +343,21 @@ test('promise support - reject', function (t) {
 		t.end();
 	});
 });
+
+test('record test duration', function (t) {
+	var avaTest;
+
+	ava(function (a) {
+		avaTest = a;
+
+		a.plan(1);
+
+		setTimeout(function () {
+			a.true(true);
+		}, 1234);
+	}).run(function (err) {
+		t.false(err);
+		t.true(avaTest.duration >= 1234);
+		t.end();
+	});
+});


### PR DESCRIPTION
Hello Sindre,

This pull request closes issue #14. It measures each test's total execution time (duration) using `process.hrtime()` and then outputs nicely formatted time near test's title:

<img width="191" alt="screen shot 2015-09-01 at 12 27 17 pm" src="https://cloud.githubusercontent.com/assets/697676/9600640/d6554c7e-50a4-11e5-82ab-70e1ee80e02f.png">

[pretty-hrtime](https://npmjs.org/package/pretty-hrtime) module is used for converting `process.hrtime()` result to a human-readable form.

Thanks for a great project, will be switching off mocha to ava soon.