### PR TITLE
Before/after hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,3 +75,5 @@ setImmediate(function () {
 
 module.exports = runner.addTest.bind(runner);
 module.exports.serial = runner.addSerialTest.bind(runner);
+module.exports.before = runner.addBeforeHook.bind(runner);
+module.exports.after = runner.addAfterHook.bind(runner);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -90,6 +90,10 @@ Runner.prototype.run = function (cb) {
 
 	// TODO: refactor this bullshit
 	this.serial(before, function () {
+		if (this.stats.failCount > 0) {
+			return this.end(cb);
+		}
+
 		this.serial(serial, function () {
 			this.concurrent(concurrent, function () {
 				this.serial(after, function () {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -19,6 +19,8 @@ function Runner(opts) {
 	this.tests = {};
 	this.tests.concurrent = [];
 	this.tests.serial = [];
+	this.tests.before = [];
+	this.tests.after = [];
 }
 
 util.inherits(Runner, EventEmitter);
@@ -32,6 +34,14 @@ Runner.prototype.addTest = function (title, cb) {
 Runner.prototype.addSerialTest = function (title, cb) {
 	this.stats.testCount++;
 	this.tests.serial.push(new Test(title, cb));
+};
+
+Runner.prototype.addBeforeHook = function (title, cb) {
+	this.tests.before.push(new Test(title, cb));
+};
+
+Runner.prototype.addAfterHook = function (title, cb) {
+	this.tests.after.push(new Test(title, cb));
 };
 
 Runner.prototype.concurrent = function (cb) {
@@ -72,26 +82,41 @@ Runner.prototype.serial = function (cb) {
 	}.bind(this), cb);
 };
 
+Runner.prototype.runBeforeHooks = function (cb) {
+	eachSerial(this.tests.before, function (test, next) {
+		test.run(function (err) {
+			if (err) {
+				this.stats.failCount++;
+			}
+
+			next();
+		}.bind(this));
+	}.bind(this), cb);
+};
+
+Runner.prototype.runAfterHooks = function (cb) {
+	eachSerial(this.tests.after, function (test, next) {
+		test.run(function (err) {
+			if (err) {
+				this.stats.failCount++;
+			}
+
+			next();
+		}.bind(this));
+	}.bind(this), cb);
+};
+
 Runner.prototype.run = function (cb) {
-	var concurrent = this.tests.concurrent;
-	var serial = this.tests.serial;
-
-	if (serial.length > 0 && concurrent.length === 0) {
-		this.serial(this.end.bind(this, cb));
-		return;
-	}
-
-	if (serial.length === 0 && concurrent.length > 0) {
-		this.concurrent(this.end.bind(this, cb));
-		return;
-	}
-
-	if (serial.length > 0 && concurrent.length > 0) {
-		this.serial(this.concurrent.bind(this, this.end.bind(this, cb)));
-		return;
-	}
-
-	this.end(cb);
+	// TODO: refactor this bullshit
+	this.runBeforeHooks(function () {
+		this.serial(function () {
+			this.concurrent(function () {
+				this.runAfterHooks(function () {
+					this.end(cb);
+				}.bind(this));
+			}.bind(this));
+		}.bind(this));
+	}.bind(this));
 };
 
 Runner.prototype.end = function (cb) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -44,8 +44,8 @@ Runner.prototype.addAfterHook = function (title, cb) {
 	this.tests.after.push(new Test(title, cb));
 };
 
-Runner.prototype.concurrent = function (cb) {
-	each(this.tests.concurrent, function (test, i, next) {
+Runner.prototype.concurrent = function (tests, cb) {
+	each(tests, function (test, i, next) {
 		test.run(function (err, duration) {
 			if (err) {
 				this.stats.failCount++;
@@ -63,8 +63,8 @@ Runner.prototype.concurrent = function (cb) {
 	}.bind(this), cb);
 };
 
-Runner.prototype.serial = function (cb) {
-	eachSerial(this.tests.serial, function (test, next) {
+Runner.prototype.serial = function (tests, cb) {
+	eachSerial(tests, function (test, next) {
 		test.run(function (err, duration) {
 			if (err) {
 				this.stats.failCount++;
@@ -77,41 +77,22 @@ Runner.prototype.serial = function (cb) {
 			});
 
 			this.emit('test', err, test.title, duration);
-			next();
-		}.bind(this));
-	}.bind(this), cb);
-};
-
-Runner.prototype.runBeforeHooks = function (cb) {
-	eachSerial(this.tests.before, function (test, next) {
-		test.run(function (err) {
-			if (err) {
-				this.stats.failCount++;
-			}
-
-			next();
-		}.bind(this));
-	}.bind(this), cb);
-};
-
-Runner.prototype.runAfterHooks = function (cb) {
-	eachSerial(this.tests.after, function (test, next) {
-		test.run(function (err) {
-			if (err) {
-				this.stats.failCount++;
-			}
-
 			next();
 		}.bind(this));
 	}.bind(this), cb);
 };
 
 Runner.prototype.run = function (cb) {
+	var concurrent = this.tests.concurrent;
+	var serial = this.tests.serial;
+	var before = this.tests.before;
+	var after = this.tests.after;
+
 	// TODO: refactor this bullshit
-	this.runBeforeHooks(function () {
-		this.serial(function () {
-			this.concurrent(function () {
-				this.runAfterHooks(function () {
+	this.serial(before, function () {
+		this.serial(serial, function () {
+			this.concurrent(concurrent, function () {
+				this.serial(after, function () {
 					this.end(cb);
 				}.bind(this));
 			}.bind(this));

--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,35 @@ test.serial(function (t) {
 ```
 
 
+### Before/after hooks
+
+There are cases, when you need to run certain functionality to prepare or clean up after tests.
+There are `test.before()` and `test.after()` functions, which are completely the same as `test()`.
+But with their help, tests can be run before or after all tests defined using `test()`.
+Before and after hooks are executed serially.
+
+```js
+// shortcuts for convenience
+var before = test.before;
+var after = test.after;
+
+before (function (t) {
+	// this test runs before all others
+	t.end();
+});
+
+after (function (t) {
+	// this test runs after all others
+	t.end();
+});
+
+test (function (t) {
+	// regular test
+	t.end();
+});
+```
+
+
 ### Custom assertion module
 
 You can use any assertion module instead or in addition to the one that comes with AVA, but you won't be able to use the `.plan()` method, [yet](https://github.com/sindresorhus/ava/issues/25).

--- a/readme.md
+++ b/readme.md
@@ -170,27 +170,26 @@ test.serial(function (t) {
 
 ### Before/after hooks
 
-There are cases, when you need to run certain functionality to prepare or clean up after tests.
-There are `test.before()` and `test.after()` functions, which are completely the same as `test()`.
-But with their help, tests can be run before or after all tests defined using `test()`.
-Before and after hooks are executed serially.
+When setup and/or teardown is required, you can use `test.before()` and `test.after()`,
+used in the same manner as `test()`.
+The test function given to `test.before()` and `test.after()` is called before/after all tests.
 
 ```js
 // shortcuts for convenience
 var before = test.before;
 var after = test.after;
 
-before (function (t) {
+before(function (t) {
 	// this test runs before all others
 	t.end();
 });
 
-after (function (t) {
+after(function (t) {
 	// this test runs after all others
 	t.end();
 });
 
-test (function (t) {
+test(function (t) {
 	// regular test
 	t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -4,54 +4,6 @@ var Promise = require('pinkie-promise');
 var ava = require('../lib/test');
 var Runner = require('../lib/runner');
 
-test('hooks - before', function (t) {
-	t.plan(1);
-
-	var runner = new Runner();
-	var arr = [];
-
-	runner.addBeforeHook(function (a) {
-		arr.push('a');
-
-		a.end();
-	});
-
-	runner.addTest(function (a) {
-		arr.push('b');
-
-		a.end();
-	});
-
-	runner.run(function () {
-		t.same(arr, ['a', 'b']);
-		t.end();
-	});
-});
-
-test('hooks - after', function (t) {
-	t.plan(1);
-
-	var runner = new Runner();
-	var arr = [];
-
-	runner.addAfterHook(function (a) {
-		arr.push('b');
-
-		a.end();
-	});
-
-	runner.addTest(function (a) {
-		arr.push('a');
-
-		a.end();
-	});
-
-	runner.run(function () {
-		t.same(arr, ['a', 'b']);
-		t.end();
-	});
-});
-
 test('run test', function (t) {
 	ava('foo', function (a) {
 		a.true(false);
@@ -406,6 +358,54 @@ test('record test duration', function (t) {
 	}).run(function (err) {
 		t.false(err);
 		t.true(avaTest.duration >= 1234);
+		t.end();
+	});
+});
+
+test('hooks - before', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addBeforeHook(function (a) {
+		arr.push('a');
+
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('b');
+
+		a.end();
+	});
+
+	runner.run(function () {
+		t.same(arr, ['a', 'b']);
+		t.end();
+	});
+});
+
+test('hooks - after', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addAfterHook(function (a) {
+		arr.push('b');
+
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('a');
+
+		a.end();
+	});
+
+	runner.run(function () {
+		t.same(arr, ['a', 'b']);
 		t.end();
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -409,3 +409,31 @@ test('hooks - after', function (t) {
 		t.end();
 	});
 });
+
+test('hooks - stop if before hooks failed', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addBeforeHook(function (a) {
+		arr.push('a');
+
+		a.end();
+	});
+
+	runner.addBeforeHook(function () {
+		throw new Error('something went wrong');
+	});
+
+	runner.addTest(function (a) {
+		arr.push('b');
+
+		a.end();
+	});
+
+	runner.run(function () {
+		t.same(arr, ['a']);
+		t.end();
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,54 @@ var Promise = require('pinkie-promise');
 var ava = require('../lib/test');
 var Runner = require('../lib/runner');
 
+test('hooks - before', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addBeforeHook(function (a) {
+		arr.push('a');
+
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('b');
+
+		a.end();
+	});
+
+	runner.run(function () {
+		t.same(arr, ['a', 'b']);
+		t.end();
+	});
+});
+
+test('hooks - after', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addAfterHook(function (a) {
+		arr.push('b');
+
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('a');
+
+		a.end();
+	});
+
+	runner.run(function () {
+		t.same(arr, ['a', 'b']);
+		t.end();
+	});
+});
+
 test('run test', function (t) {
 	ava('foo', function (a) {
 		a.true(false);


### PR DESCRIPTION
Fixes #4.

Hooks are completely the same as regular tests and provide the same functionality/API.
The only thing different is **when** they are executed.

### Changes

- Add `test.before()` to execute a test before all others
- Add `test.after()` to execute a test after all others
- Refactor `Runner.prototype.concurrent` and `Runner.prototype.serial` to accept array of tests, instead of getting them directly from `this.tests.concurrent` and `this.tests.serial` properties respectively
- Add tests
- Add information about before/after hooks to the readme

### Behavior

After this change, here is how Ava runs tests:

1. before hooks
2. serial tests
3. concurrent tests
4. after hooks

*Update*: If at least one before hook fails, all the following tests won't be executed.

### Usage

```js
var test = require('ava');

// shortcuts for convenience
var before = test.before;
var after = test.after;

before('before hook', function (t) {
  // this will run before everything else

  t.end();
});

after('after hook', function (t) {
  // this will run after everything else is completed

  t.end();
});

test('regular test', function (t) {
  t.end();
});
```

Output:

<img width="299" alt="screen shot 2015-09-05 at 1 50 53 pm" src="https://cloud.githubusercontent.com/assets/697676/9698918/32a495ba-53d5-11e5-9215-ed01bde4cb02.png">


### Tests

Tests were added to cover new `test.before()` and `test.after()` functions.


Let me know what you think!