### PR TITLE
remove EventEmitter from Test

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1,9 +1,7 @@
 'use strict';
 var Promise = require('bluebird');
 var setImmediate = require('set-immediate-shim');
-var util = require('util');
 var assert = require('assert');
-var EventEmitter = require('events').EventEmitter;
 var fnName = require('fn-name');
 var claim = require('claim');
 
@@ -17,8 +15,6 @@ function Test(title, fn) {
 		title = null;
 	}
 
-	EventEmitter.call(this);
-
 	this.title = title || fnName(fn) || '[anonymous]';
 	this.fn = fn;
 	this.assertCount = 0;
@@ -30,7 +26,6 @@ function Test(title, fn) {
 	this._timeStart = null;
 }
 
-util.inherits(Test, EventEmitter);
 module.exports = Test;
 
 Test.prototype._assert = function () {


### PR DESCRIPTION
`EventEmmitter` is not used in `Test` class and seems like won't be used in future (nor exposed in readme).