### PR TITLE
Allow custom assert modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,3 +96,4 @@ module.exports = runner.addTest.bind(runner);
 module.exports.serial = runner.addSerialTest.bind(runner);
 module.exports.before = runner.addBeforeHook.bind(runner);
 module.exports.after = runner.addAfterHook.bind(runner);
+module.exports.setAssertModule = runner.setAssertModule.bind(runner);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -92,11 +92,6 @@ Runner.prototype._addTestResult = function (test) {
 };
 
 Runner.prototype.run = function () {
-	// Set default assert module if needed
-	if (!this._assertModule) {
-		Test._setAssertModule();
-	}
-
 	var self = this;
 	var tests = this.tests;
 	var stats = this.stats;
@@ -126,5 +121,5 @@ Runner.prototype.run = function () {
 
 // Set custom assert module
 Runner.prototype.setAssertModule = function (assertModule) {
-	this._assertModule = Test._setAssertModule(assertModule);
+	Test._setAssertModule(assertModule);
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -24,6 +24,8 @@ function Runner(opts) {
 		before: [],
 		after: []
 	};
+
+	this._assertModule = null;
 }
 
 util.inherits(Runner, EventEmitter);
@@ -31,20 +33,20 @@ module.exports = Runner;
 
 Runner.prototype.addTest = function (title, cb) {
 	this.stats.testCount++;
-	this.tests.concurrent.push(new Test(title, cb));
+	this.tests.concurrent.push(new Test(title, this._assertModule, cb));
 };
 
 Runner.prototype.addSerialTest = function (title, cb) {
 	this.stats.testCount++;
-	this.tests.serial.push(new Test(title, cb));
+	this.tests.serial.push(new Test(title, this._assertModule, cb));
 };
 
 Runner.prototype.addBeforeHook = function (title, cb) {
-	this.tests.before.push(new Test(title, cb));
+	this.tests.before.push(new Test(title, this._assertModule, cb));
 };
 
 Runner.prototype.addAfterHook = function (title, cb) {
-	this.tests.after.push(new Test(title, cb));
+	this.tests.after.push(new Test(title, this._assertModule, cb));
 };
 
 Runner.prototype.concurrent = function (tests) {
@@ -121,5 +123,5 @@ Runner.prototype.run = function () {
 
 // Set custom assert module
 Runner.prototype.setAssertModule = function (assertModule) {
-	Test._setAssertModule(assertModule);
+	this._assertModule = assertModule;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -92,6 +92,11 @@ Runner.prototype._addTestResult = function (test) {
 };
 
 Runner.prototype.run = function () {
+	// Set default assert module if needed
+	if (!this._assertModule) {
+		Test._setAssertModule();
+	}
+
 	var self = this;
 	var tests = this.tests;
 	var stats = this.stats;
@@ -117,4 +122,9 @@ Runner.prototype.run = function () {
 		.then(function () {
 			stats.passCount = stats.testCount - stats.failCount;
 		});
+};
+
+// Set custom assert module
+Runner.prototype.setAssertModule = function (assertModule) {
+	this._assertModule = Test._setAssertModule(assertModule);
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -45,17 +45,25 @@ Test.prototype._assert = function () {
 
 Test.prototype._setAssertModule = function (assertModule) {
 	var lib = assertModule || assert;
-	Object.keys(lib).forEach(function (el) {
-		Test.prototype[el] = function () {
-			this._assert();
 
-			try {
-				lib[el].apply(lib, arguments);
-			} catch (err) {
-				this.assertError = err;
-			}
-		};
-	});
+	if (typeof lib === 'function') {
+		setPrototype(lib.name, lib);
+	} else if (typeof lib === 'object') {
+		Object.keys(lib).forEach(function (el) {
+			setPrototype(el, lib[el]);
+		});
+	}
+
+	function setPrototype(el, method) {
+		Object.defineProperty(Test.prototype, el, {
+			get: function () {
+				this._assert();
+
+				return method;
+			},
+			configurable: true
+		});
+	}
 };
 
 Test.prototype.plan = function (count) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -4,14 +4,19 @@ var setImmediate = require('set-immediate-shim');
 var fnName = require('fn-name');
 var assert = require('./assert');
 
-function Test(title, fn) {
+function Test(title, assertModule, fn) {
 	if (!(this instanceof Test)) {
-		return new Test(title, fn);
+		return new Test(title, assertModule, fn);
 	}
 
-	if (typeof title !== 'string') {
-		fn = title;
-		title = null;
+	if (fn === undefined) {
+		if (typeof assertModule === 'function') {
+			fn = assertModule;
+			assertModule = null;
+		} else if (typeof title === 'function') {
+			fn = title;
+			title = null;
+		}
 	}
 
 	this.title = title || fnName(fn) || '[anonymous]';
@@ -23,6 +28,9 @@ function Test(title, fn) {
 	// store the time point before test execution
 	// to calculate the total time spent in test
 	this._timeStart = null;
+
+	// Set assert module
+	this._setAssertModule(assertModule);
 }
 
 module.exports = Test;
@@ -35,7 +43,7 @@ Test.prototype._assert = function () {
 	}
 };
 
-(Test._setAssertModule = function (assertModule) {
+Test.prototype._setAssertModule = function (assertModule) {
 	var lib = assertModule || assert;
 	Object.keys(lib).forEach(function (el) {
 		Test.prototype[el] = function () {
@@ -48,7 +56,7 @@ Test.prototype._assert = function () {
 			}
 		};
 	});
-})();
+};
 
 Test.prototype.plan = function (count) {
 	if (typeof count !== 'number') {

--- a/lib/test.js
+++ b/lib/test.js
@@ -35,17 +35,22 @@ Test.prototype._assert = function () {
 	}
 };
 
-Object.keys(assert).forEach(function (el) {
-	Test.prototype[el] = function () {
-		this._assert();
+Test._setAssertModule = function (assertModule) {
+	var lib = assertModule || assert;
+	Object.keys(lib).forEach(function (el) {
+		Test.prototype[el] = function () {
+			this._assert();
 
-		try {
-			assert[el].apply(assert, arguments);
-		} catch (err) {
-			this.assertError = err;
-		}
-	};
-});
+			try {
+				lib[el].apply(lib, arguments);
+			} catch (err) {
+				this.assertError = err;
+			}
+		};
+	});
+
+	return (assertModule) ? 'custom' : 'default';
+};
 
 Test.prototype.plan = function (count) {
 	if (typeof count !== 'number') {

--- a/lib/test.js
+++ b/lib/test.js
@@ -35,7 +35,7 @@ Test.prototype._assert = function () {
 	}
 };
 
-Test._setAssertModule = function (assertModule) {
+(Test._setAssertModule = function (assertModule) {
 	var lib = assertModule || assert;
 	Object.keys(lib).forEach(function (el) {
 		Test.prototype[el] = function () {
@@ -48,9 +48,7 @@ Test._setAssertModule = function (assertModule) {
 			}
 		};
 	});
-
-	return (assertModule) ? 'custom' : 'default';
-};
+})();
 
 Test.prototype.plan = function (count) {
 	if (typeof count !== 'number') {

--- a/lib/test.js
+++ b/lib/test.js
@@ -10,12 +10,12 @@ function Test(title, assertModule, fn) {
 	}
 
 	if (fn === undefined) {
-		if (typeof assertModule === 'function') {
-			fn = assertModule;
-			assertModule = null;
-		} else if (typeof title === 'function') {
+		if (typeof title === 'function') {
 			fn = title;
 			title = null;
+		} else if (typeof assertModule === 'function') {
+			fn = assertModule;
+			assertModule = null;
 		}
 	}
 


### PR DESCRIPTION
Allows you to set a custom assert module so it can be used together with `plan()`.
```
var test = require('ava')
var assert = require('assert');
test.setAssertModule(assert);
```

#25