### PR TITLE
Easier debugging when not overwriting already existing assertErrors

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -107,7 +107,7 @@ Test.prototype.exit = function () {
 	// calculate total time spent in test
 	this.duration = Date.now() - this._timeStart;
 
-	if (this.planCount !== null && this.planCount !== this.assertCount) {
+	if (!this.assertError && this.planCount !== null && this.planCount !== this.assertCount) {
 		this.assertError = new assert.AssertionError({
 			actual: this.assertCount,
 			expected: this.planCount,

--- a/test/test.js
+++ b/test/test.js
@@ -80,6 +80,17 @@ test('handle non-assertion errors', function (t) {
 	});
 });
 
+test('handle non-assertion errors even when planned', function (t) {
+	ava(function (a) {
+		a.plan(1);
+		throw new Error();
+	}).run().catch(function (err) {
+		t.is(err.name, 'Error');
+		t.true(err instanceof Error);
+		t.end();
+	});
+});
+
 test('handle testing of arrays', function (t) {
 	ava(function (a) {
 		a.same(['foo', 'bar'], ['foo', 'bar']);


### PR DESCRIPTION
Having a test with a `plan` which throws an unexpected error like so:

```javascript
var test = require('ava');

test(function unexpected(t) {
  t.plan(1);
  var o = {};
  o();
});
```

Will at the moment only report an error about assert count not matching planned count, even though an `assertError` already have been set. This addresses that by not overwriting an existing assert error, which gives the correct error message:

```
TypeError: o is not a function
```

What do you think?