### PR TITLE
workarounds for browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,9 @@ function exit() {
 		stack(results);
 	}
 
-	process.exit(stats.failCount > 0 ? 1 : 0);
+	if (process.exit) {
+		process.exit(stats.failCount > 0 ? 1 : 0);
+	}
 }
 
 setImmediate(function () {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var figures = require('figures');
 var Squeak = require('squeak');
 var plur = require('plur');
 var Runner = require('./lib/runner');
-var log = new Squeak({separator: ' '});
+var consoleStream = require('console-stream');
+var log = new Squeak({separator: ' ', stream: process.stderr || consoleStream()});
 var runner = new Runner();
 
 Error.stackTraceLimit = Infinity;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-core": "^5.8.23",
     "bluebird": "^2.9.34",
     "chalk": "^1.0.0",
+    "console-stream": "^0.1.1",
     "figures": "^1.3.5",
     "fn-name": "^2.0.0",
     "globby": "^3.0.1",


### PR DESCRIPTION
fixes #24 

- if `stderr` is not available, inject the console in `squeak`
- `process.exit` is not available in the browser. Don't call the method if it is not available.