### PR TITLE
Add support for generator and async functions

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1,4 +1,5 @@
 'use strict';
+var isGenerator = require('is-generator').fn;
 var Promise = require('bluebird');
 var setImmediate = require('set-immediate-shim');
 var fnName = require('fn-name');
@@ -15,7 +16,7 @@ function Test(title, fn) {
 	}
 
 	this.title = title || fnName(fn) || '[anonymous]';
-	this.fn = fn;
+	this.fn = isGenerator(fn) ? Promise.coroutine(fn) : fn;
 	this.assertCount = 0;
 	this.planCount = null;
 	this.duration = null;

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "figures": "^1.3.5",
     "fn-name": "^2.0.0",
     "globby": "^3.0.1",
+    "is-generator": "^1.0.2",
     "meow": "^3.3.0",
     "object-assign": "^4.0.1",
     "plur": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ test(function (t) {
 });
 ```
 
-### Generators support
+### Generator function support
 
 AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) and  out-of-the-box. 
 
@@ -193,12 +193,19 @@ test(function * (t) {
 });
 ```
 
-### async/await support
+### Async function support
 
-AVA also supports [async/await](https://github.com/yortus/asyncawait) with no configuration required.
+AVA also supports [async functions](https://tc39.github.io/ecmascript-asyncawait/) *(async/await)* with no configuration required.
 
 ```js
 test(async function (t) {
+	const value = await promiseFn();
+
+	t.end();
+});
+
+// async arrow functions
+test(async t => {
 	const value = await promiseFn();
 
 	t.end();

--- a/readme.md
+++ b/readme.md
@@ -255,14 +255,20 @@ You can also use your own local Babel version:
 ```
 
 
-### Generators support
+### Generators and async/await support
 
-AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) out-of-the-box. 
+AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) and [async/await](https://github.com/yortus/asyncawait) out-of-the-box. 
 
 ```js
 test(function * (t) {
 	let value = yield generatorFn();
 	
+	t.end();
+});
+
+test(async function (t) {
+	let value = await promiseFn();
+
 	t.end();
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -181,19 +181,25 @@ test(function (t) {
 });
 ```
 
-### Generators and async/await support
+### Generators support
 
-AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) and [async/await](https://github.com/yortus/asyncawait) out-of-the-box. 
+AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) and  out-of-the-box. 
 
 ```js
 test(function * (t) {
-	let value = yield generatorFn();
+	const value = yield generatorFn();
 	
 	t.end();
 });
+```
 
+### async/await support
+
+AVA also supports [async/await](https://github.com/yortus/asyncawait) with no configuration required.
+
+```js
 test(async function (t) {
-	let value = await promiseFn();
+	const value = await promiseFn();
 
 	t.end();
 });

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,23 @@ test(function (t) {
 });
 ```
 
+### Generators and async/await support
+
+AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) and [async/await](https://github.com/yortus/asyncawait) out-of-the-box. 
+
+```js
+test(function * (t) {
+	let value = yield generatorFn();
+	
+	t.end();
+});
+
+test(async function (t) {
+	let value = await promiseFn();
+
+	t.end();
+});
+```
 
 ### Serial test execution
 
@@ -252,25 +269,6 @@ You can also use your own local Babel version:
 		"babel-core": "^5.8.0"
 	}
 }
-```
-
-
-### Generators and async/await support
-
-AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) and [async/await](https://github.com/yortus/asyncawait) out-of-the-box. 
-
-```js
-test(function * (t) {
-	let value = yield generatorFn();
-	
-	t.end();
-});
-
-test(async function (t) {
-	let value = await promiseFn();
-
-	t.end();
-});
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,19 @@ You can also use your own local Babel version:
 ```
 
 
+### Generators support
+
+AVA supports [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) out-of-the-box. 
+
+```js
+test(function * (t) {
+	let value = yield generatorFn();
+	
+	t.end();
+});
+```
+
+
 ## API
 
 ### test([name], body)

--- a/test/fixture/async-await.js
+++ b/test/fixture/async-await.js
@@ -5,7 +5,7 @@ const test = require('../../');
 test(async function (t) {
 	t.plan(1);
 
-	let value = await Promise.resolve(1);
+	const value = await Promise.resolve(1);
 
 	t.is(value, 1);
 });

--- a/test/fixture/async-await.js
+++ b/test/fixture/async-await.js
@@ -9,3 +9,11 @@ test(async function (t) {
 
 	t.is(value, 1);
 });
+
+test(async t => {
+	t.plan(1);
+
+	const value = await Promise.resolve(1);
+
+	t.is(value, 1);
+});

--- a/test/fixture/async-await.js
+++ b/test/fixture/async-await.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const test = require('../../');
+
+test(async function (t) {
+	t.plan(1);
+
+	let value = await Promise.resolve(1);
+
+	t.is(value, 1);
+});

--- a/test/fixture/generators.js
+++ b/test/fixture/generators.js
@@ -2,7 +2,7 @@
 
 const test = require('../../');
 
-test ('generators', function * (t) {
+test(function * (t) {
 	t.plan(1);
 
 	const value = yield Promise.resolve(1);

--- a/test/fixture/generators.js
+++ b/test/fixture/generators.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const test = require('../../');
+
+test ('generators', function * (t) {
+	t.plan(1);
+
+	let value = yield Promise.resolve(1);
+
+	t.is(value, 1);
+});

--- a/test/fixture/generators.js
+++ b/test/fixture/generators.js
@@ -5,7 +5,7 @@ const test = require('../../');
 test ('generators', function * (t) {
 	t.plan(1);
 
-	let value = yield Promise.resolve(1);
+	const value = yield Promise.resolve(1);
 
 	t.is(value, 1);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -446,9 +446,7 @@ test('hooks - stop if before hooks failed', function (t) {
 test('ES2015 support', function (t) {
 	t.plan(1);
 
-	childProcess.execFile('../cli.js', ['fixture/es2015.js'], {
-		cwd: __dirname
-	}, function (err) {
+	exec('fixture/es2015.js', function (err) {
 		t.ifError(err);
 	});
 });
@@ -456,11 +454,7 @@ test('ES2015 support', function (t) {
 test('generators support', function (t) {
 	t.plan(1);
 
-	var options = {
-		cwd: __dirname
-	};
-
-	childProcess.execFile('../cli.js', ['fixture/generators.js'], options, function (err) {
+	exec('fixture/generators.js', function (err) {
 		t.ifError(err);
 	});
 });
@@ -468,11 +462,11 @@ test('generators support', function (t) {
 test('async/await support', function (t) {
 	t.plan(1);
 
-	var options = {
-		cwd: __dirname
-	};
-
-	childProcess.execFile('../cli.js', ['fixture/async-await.js'], options, function (err) {
+	exec('fixture/async-await.js', function (err) {
 		t.ifError(err);
 	});
 });
+
+function exec(file, cb) {
+	childProcess.execFile('../cli.js', [file], {cwd: __dirname}, cb);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -464,3 +464,15 @@ test('generators support', function (t) {
 		t.ifError(err);
 	});
 });
+
+test('async/await support', function (t) {
+	t.plan(1);
+
+	var options = {
+		cwd: __dirname
+	};
+
+	childProcess.execFile('../cli.js', ['fixture/async-await.js'], options, function (err) {
+		t.ifError(err);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -452,3 +452,15 @@ test('ES2015 support', function (t) {
 		t.ifError(err);
 	});
 });
+
+test('generators support', function (t) {
+	t.plan(1);
+
+	var options = {
+		cwd: __dirname
+	};
+
+	childProcess.execFile('../cli.js', ['fixture/generators.js'], options, function (err) {
+		t.ifError(err);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,10 @@ var test = require('tape');
 var Runner = require('../lib/runner');
 var ava = require('../lib/test');
 
+function execCli(file, cb) {
+	childProcess.execFile('../cli.js', [file], {cwd: __dirname}, cb);
+}
+
 test('run test', function (t) {
 	ava('foo', function (a) {
 		a.fail();
@@ -446,7 +450,7 @@ test('hooks - stop if before hooks failed', function (t) {
 test('ES2015 support', function (t) {
 	t.plan(1);
 
-	exec('fixture/es2015.js', function (err) {
+	execCli('fixture/es2015.js', function (err) {
 		t.ifError(err);
 	});
 });
@@ -454,7 +458,7 @@ test('ES2015 support', function (t) {
 test('generators support', function (t) {
 	t.plan(1);
 
-	exec('fixture/generators.js', function (err) {
+	execCli('fixture/generators.js', function (err) {
 		t.ifError(err);
 	});
 });
@@ -462,11 +466,7 @@ test('generators support', function (t) {
 test('async/await support', function (t) {
 	t.plan(1);
 
-	exec('fixture/async-await.js', function (err) {
+	execCli('fixture/async-await.js', function (err) {
 		t.ifError(err);
 	});
 });
-
-function exec(file, cb) {
-	childProcess.execFile('../cli.js', [file], {cwd: __dirname}, cb);
-}


### PR DESCRIPTION
Fixes #37.
Fixes #45.

### Changes

This PR uses [is-generator](https://npmjs.org/package/is-generator) module to detect if a test's function is a *generator* function. If true, function gets converted to a promise using `Bluebird.coroutine()`.


### Results

As a result of this PR, generators are fully supported with all the same API. As a side effect, `async/await` is also supported by enabling `asyncToGenerator` in babel.