### PR TITLE
Fix passed/failed counters

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -61,9 +61,13 @@ function run(file) {
 }
 
 function sum(arr, key) {
-	return arr.reduce(function (a, b) {
-		return a[key] + b[key];
+	var result = 0;
+
+	arr.forEach(function (item) {
+		result += item[key];
 	});
+
+	return result;
 }
 
 function exit(results) {


### PR DESCRIPTION
This PR fixes a bug caused by #47.

### Bug

When there is only one test file, AVA does not report a number of passed/failed tests.

<img width="300" alt="screen shot 2015-09-18 at 10 35 34 am" src="https://cloud.githubusercontent.com/assets/697676/9954386/3fadf9ec-5df1-11e5-82ac-022f8adedc71.png">


### Reason

The reason is the `sum()` function, that is used to sum up all passed/failed counters from all tests:

```js
function sum(arr, key) {
	return arr.reduce(function (a, b) {
		return a[key] + b[key];
	});
}
```

When `arr` has only one item, it simply returns it, without calculating a sum, which leads to a reported bug.


### Fix

Fix is very simple:

```js
function sum(arr, key) {
	var result = 0;

	arr.forEach(function (item) {
		result += item[key];
	});

	return result;
}
```

<img width="134" alt="screen shot 2015-09-18 at 10 35 18 am" src="https://cloud.githubusercontent.com/assets/697676/9954411/7b614c50-5df1-11e5-83b2-7644b032be48.png">
