### PR TITLE
Prefix test title with test location

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -2,10 +2,12 @@
 
 var resolveFrom = require('resolve-from');
 
+var hasGenerators = parseInt(process.version.slice(1), 10) > 0;
+
 var options = {
 	only: /(test|test\-.+|test\/.+)\.js$/,
-	blacklist: ['regenerator'],
-	optional: ['asyncToGenerator']
+	blacklist: hasGenerators ? ['regenerator'] : [],
+	optional: hasGenerators ? ['asyncToGenerator'] : []
 };
 
 try {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -32,6 +32,8 @@ function fork(file) {
 
 	// emit `test` and `stats` events
 	ps.on('message', function (event) {
+		event.data.file = file;
+
 		ps.emit(event.name, event.data);
 	});
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chalk": "^1.0.0",
     "co": "^4.6.0",
     "core-assert": "^0.1.0",
-    "figures": "^1.3.5",
+    "figures": "^1.4.0",
     "fn-name": "^2.0.0",
     "globby": "^3.0.1",
     "is-generator": "^1.0.2",

--- a/test/fixture/async-await.js
+++ b/test/fixture/async-await.js
@@ -2,7 +2,7 @@
 
 const test = require('../../');
 
-test(async function (t) {
+test('async function', async function (t) {
 	t.plan(1);
 
 	const value = await Promise.resolve(1);
@@ -10,7 +10,7 @@ test(async function (t) {
 	t.is(value, 1);
 });
 
-test(async t => {
+test('arrow async function', async t => {
 	t.plan(1);
 
 	const value = await Promise.resolve(1);

--- a/test/fixture/generators.js
+++ b/test/fixture/generators.js
@@ -2,7 +2,7 @@
 
 const test = require('../../');
 
-test(function * (t) {
+test('generator function', function * (t) {
 	t.plan(1);
 
 	const value = yield Promise.resolve(1);


### PR DESCRIPTION
Fixes #53 

Uses `figures.pointerSmall` to replace `/` and as a separator between prefix and test title.