### PR TITLE
Wait for pending tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -6,6 +6,8 @@ var fnName = require('fn-name');
 var assert = require('./assert');
 var co = require('co');
 
+var TIMEOUT_MAX_VALUE = 2147483647;
+
 function Test(title, fn) {
 	if (!(this instanceof Test)) {
 		return new Test(title, fn);
@@ -75,6 +77,9 @@ Test.prototype.run = function () {
 
 		this._timeStart = Date.now();
 
+		// wait until all assertions are complete
+		this._timeout = setTimeout(function () {}, TIMEOUT_MAX_VALUE);
+
 		try {
 			var ret = this.fn(this);
 
@@ -108,6 +113,9 @@ Test.prototype.end = function () {
 Test.prototype.exit = function () {
 	// calculate total time spent in test
 	this.duration = Date.now() - this._timeStart;
+
+	// stop infinite timer
+	clearTimeout(this._timeout);
 
 	if (!this.assertError && this.planCount !== null && this.planCount !== this.assertCount) {
 		this.assertError = new assert.AssertionError({

--- a/test/test.js
+++ b/test/test.js
@@ -470,3 +470,22 @@ test('async/await support', function (t) {
 		t.ifError(err);
 	});
 });
+
+test('wait for test to end', function (t) {
+	var avaTest;
+
+	ava(function (a) {
+		a.plan(1);
+
+		avaTest = a;
+	}).run().then(function (a) {
+		t.is(a.planCount, 1);
+		t.is(a.assertCount, 1);
+		t.true(a.duration >= 1234);
+		t.end();
+	});
+
+	setTimeout(function () {
+		avaTest.pass();
+	}, 1234);
+});


### PR DESCRIPTION
Fixes #63, related to #15.


### Changes

Before test `.run()`, timer with maximum possible value is started to keep the process alive. When the test is finished, `clearTimeout()` removes the timeout.


### Fixed cases

Now, the following tests won't just produce empty output:

```js
test('empty test', function (t) {

});

test('no assertions', function (t) {
  t.plan(1);
});
```