### PR TITLE
Add beforeEach/afterEach hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,3 +85,5 @@ module.exports = runner.addTest.bind(runner);
 module.exports.serial = runner.addSerialTest.bind(runner);
 module.exports.before = runner.addBeforeHook.bind(runner);
 module.exports.after = runner.addAfterHook.bind(runner);
+module.exports.beforeEach = runner.addBeforeEachHook.bind(runner);
+module.exports.afterEach = runner.addAfterEachHook.bind(runner);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,6 @@
 'use strict';
 var util = require('util');
+var flatten = require('arr-flatten');
 var EventEmitter = require('events').EventEmitter;
 var Promise = require('bluebird');
 var Test = require('./test');
@@ -22,7 +23,9 @@ function Runner(opts) {
 		concurrent: [],
 		serial: [],
 		before: [],
-		after: []
+		after: [],
+		beforeEach: [],
+		afterEach: []
 	};
 }
 
@@ -47,8 +50,48 @@ Runner.prototype.addAfterHook = function (title, cb) {
 	this.tests.after.push(new Test(title, cb));
 };
 
+Runner.prototype.addBeforeEachHook = function (title, cb) {
+	this.tests.beforeEach.push({
+		title: title,
+		fn: cb
+	});
+};
+
+Runner.prototype.addAfterEachHook = function (title, cb) {
+	this.tests.afterEach.push({
+		title: title,
+		fn: cb
+	});
+};
+
+Runner.prototype._wrapTestWithHooks = function (test) {
+	var self = this;
+
+	var beforeHooks = self.tests.beforeEach.map(function (hook) {
+		return new Test(hook.title, hook.fn);
+	});
+
+	var afterHooks = self.tests.afterEach.map(function (hook) {
+		return new Test(hook.title, hook.fn);
+	});
+
+	var tests = [];
+
+	tests.push.apply(tests, beforeHooks);
+	tests.push(test);
+	tests.push.apply(tests, afterHooks);
+
+	return tests;
+};
+
 Runner.prototype.concurrent = function (tests) {
 	var self = this;
+
+	tests = tests.map(function (test) {
+		return self._wrapTestWithHooks(test);
+	});
+
+	tests = flatten(tests);
 
 	// run all tests
 	return Promise.all(tests.map(function (test) {
@@ -65,6 +108,12 @@ Runner.prototype.concurrent = function (tests) {
 
 Runner.prototype.serial = function (tests) {
 	var self = this;
+
+	tests = tests.map(function (test) {
+		return self._wrapTestWithHooks(test);
+	});
+
+	tests = flatten(tests);
 
 	return Promise.resolve(tests).each(function (test) {
 		return test.run()

--- a/test/test.js
+++ b/test/test.js
@@ -448,6 +448,70 @@ test('hooks - stop if before hooks failed', function (t) {
 	});
 });
 
+test('hooks - before each', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addBeforeEachHook(function (a) {
+		arr.push('a');
+		a.end();
+	});
+
+	runner.addBeforeEachHook(function (a) {
+		arr.push('b');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('c');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('d');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.same(arr, ['a', 'b', 'c', 'a', 'b', 'd']);
+		t.end();
+	});
+});
+
+test('hooks - after each', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addAfterEachHook(function (a) {
+		arr.push('a');
+		a.end();
+	});
+
+	runner.addAfterEachHook(function (a) {
+		arr.push('b');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('c');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('d');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.same(arr, ['c', 'a', 'b', 'd', 'a', 'b']);
+		t.end();
+	});
+});
+
 test('ES2015 support', function (t) {
 	t.plan(1);
 


### PR DESCRIPTION
This PR adds `beforeEach()` and `afterEach()` methods to Ava.

As names hint, these functions add hooks that are executed before & after each test.

There is one difference though, if `beforeEach` hook fails, tests don't stop (unlike `before()`).

So, let's discuss this!