### PR TITLE
Add beforeEach/afterEach hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,3 +85,5 @@ module.exports = runner.addTest.bind(runner);
 module.exports.serial = runner.addSerialTest.bind(runner);
 module.exports.before = runner.addBeforeHook.bind(runner);
 module.exports.after = runner.addAfterHook.bind(runner);
+module.exports.beforeEach = runner.addBeforeEachHook.bind(runner);
+module.exports.afterEach = runner.addAfterEachHook.bind(runner);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,6 +4,14 @@ var EventEmitter = require('events').EventEmitter;
 var Promise = require('bluebird');
 var Test = require('./test');
 
+function each(items, fn) {
+	return Promise.all(items.map(fn));
+}
+
+function eachSeries(items, fn) {
+	return Promise.resolve(items).each(fn);
+}
+
 function Runner(opts) {
 	if (!(this instanceof Runner)) {
 		return new Runner(opts);
@@ -22,7 +30,9 @@ function Runner(opts) {
 		concurrent: [],
 		serial: [],
 		before: [],
-		after: []
+		after: [],
+		beforeEach: [],
+		afterEach: []
 	};
 }
 
@@ -47,34 +57,53 @@ Runner.prototype.addAfterHook = function (title, cb) {
 	this.tests.after.push(new Test(title, cb));
 };
 
-Runner.prototype.concurrent = function (tests) {
+Runner.prototype.addBeforeEachHook = function (title, cb) {
+	this.tests.beforeEach.push({
+		title: title,
+		fn: cb
+	});
+};
+
+Runner.prototype.addAfterEachHook = function (title, cb) {
+	this.tests.afterEach.push({
+		title: title,
+		fn: cb
+	});
+};
+
+Runner.prototype._runTest = function (test) {
 	var self = this;
 
-	// run all tests
-	return Promise.all(tests.map(function (test) {
+	var beforeHooks = self.tests.beforeEach.map(function (hook) {
+		return new Test(hook.title, hook.fn);
+	});
+
+	var afterHooks = self.tests.afterEach.map(function (hook) {
+		return new Test(hook.title, hook.fn);
+	});
+
+	var tests = [];
+
+	tests.push.apply(tests, beforeHooks);
+	tests.push(test);
+	tests.push.apply(tests, afterHooks);
+
+	return eachSeries(tests, function (test) {
+		// add test result regardless of state
+		// but on error, don't execute next tests
 		return test.run()
-			.catch(function () {
-				// in case of error, don't reject a promise
-				return;
-			})
-			.then(function () {
+			.finally(function () {
 				self._addTestResult(test);
 			});
-	}));
+	}).catch(function () {});
+};
+
+Runner.prototype.concurrent = function (tests) {
+	return each(tests, this._runTest.bind(this));
 };
 
 Runner.prototype.serial = function (tests) {
-	var self = this;
-
-	return Promise.resolve(tests).each(function (test) {
-		return test.run()
-			.catch(function () {
-				return;
-			})
-			.then(function () {
-				self._addTestResult(test);
-			});
-	});
+	return eachSeries(tests, this._runTest.bind(this));
 };
 
 Runner.prototype._addTestResult = function (test) {

--- a/readme.md
+++ b/readme.md
@@ -185,7 +185,7 @@ test.serial(function (t) {
 ### Before/after hooks
 
 When setup and/or teardown is required, you can use `test.before()` and `test.after()`,
-used in the same manner as `test()`. The test function given to `test.before()` and `test.after()` is called before/after all tests.
+used in the same manner as `test()`. The test function given to `test.before()` and `test.after()` is called before/after all tests. You can also use `test.beforeEach()` and `test.afterEach()`, if you need setup/teardown for each test.
 
 ```js
 test.before(function (t) {
@@ -195,6 +195,16 @@ test.before(function (t) {
 
 test.after(function (t) {
 	// this test runs after all others
+	t.end();
+});
+
+test.beforeEach(function (t) {
+	// this test runs before each test
+	t.end();
+});
+
+test.afterEach(function (t) {
+	// this test runs after each test
 	t.end();
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -448,6 +448,163 @@ test('hooks - stop if before hooks failed', function (t) {
 	});
 });
 
+test('hooks - before each with concurrent tests', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [[], []];
+	var i = 0;
+	var k = 0;
+
+	runner.addBeforeEachHook(function (a) {
+		arr[i++].push('a');
+		a.end();
+	});
+
+	runner.addBeforeEachHook(function (a) {
+		arr[k++].push('b');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr[0].push('c');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr[1].push('d');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.same(arr, [['a', 'b', 'c'], ['a', 'b', 'd']]);
+		t.end();
+	});
+});
+
+test('hooks - before each with serial tests', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addBeforeEachHook(function (a) {
+		arr.push('a');
+		a.end();
+	});
+
+	runner.addBeforeEachHook(function (a) {
+		arr.push('b');
+		a.end();
+	});
+
+	runner.addSerialTest(function (a) {
+		arr.push('c');
+		a.end();
+	});
+
+	runner.addSerialTest(function (a) {
+		arr.push('d');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.same(arr, ['a', 'b', 'c', 'a', 'b', 'd']);
+		t.end();
+	});
+});
+
+test('hooks - fail if beforeEach hook fails', function (t) {
+	t.plan(2);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addBeforeEachHook(function (a) {
+		arr.push('a');
+		a.fail();
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('b');
+		a.pass();
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.is(runner.stats.failCount, 1);
+		t.same(arr, ['a']);
+		t.end();
+	});
+});
+
+test('hooks - after each with concurrent tests', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [[], []];
+	var i = 0;
+	var k = 0;
+
+	runner.addAfterEachHook(function (a) {
+		arr[i++].push('a');
+		a.end();
+	});
+
+	runner.addAfterEachHook(function (a) {
+		arr[k++].push('b');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr[0].push('c');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr[1].push('d');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.same(arr, [['c', 'a', 'b'], ['d', 'a', 'b']]);
+		t.end();
+	});
+});
+
+test('hooks - after each with serial tests', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addAfterEachHook(function (a) {
+		arr.push('a');
+		a.end();
+	});
+
+	runner.addAfterEachHook(function (a) {
+		arr.push('b');
+		a.end();
+	});
+
+	runner.addSerialTest(function (a) {
+		arr.push('c');
+		a.end();
+	});
+
+	runner.addSerialTest(function (a) {
+		arr.push('d');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.same(arr, ['c', 'a', 'b', 'd', 'a', 'b']);
+		t.end();
+	});
+});
+
 test('ES2015 support', function (t) {
 	t.plan(1);
 


### PR DESCRIPTION
This PR adds `beforeEach()` and `afterEach()` methods to Ava.

These functions allow to add hooks that are executed before & after each test.
`beforeEach` and `afterEach` hooks execute serially, just like `before` and `after`.

There is one difference though, if `beforeEach` hook fails, tests don't stop (unlike `before`).

So, let's discuss this!