### PR TITLE
Handle promises in throws() and doesNotThrow()

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -69,6 +69,24 @@ x.notSame = function (val, expected, msg) {
 };
 
 x.throws = function (fn, err, msg) {
+	if (fn && fn.then) {
+		err = err || Error;
+
+		return fn
+			.catch(err, function (err) {
+				return err;
+			})
+			.then(function (value) {
+				if (value instanceof err) {
+					return;
+				}
+
+				x.throws(function () {
+					throw value;
+				}, err, msg);
+			});
+	}
+
 	try {
 		assert.throws(fn, err, msg);
 	} catch (err) {
@@ -77,6 +95,15 @@ x.throws = function (fn, err, msg) {
 };
 
 x.doesNotThrow = function (fn, msg) {
+	if (fn && fn.then) {
+		return fn
+			.catch(function (err) {
+				x.doesNotThrow(function () {
+					throw err;
+				}, msg);
+			});
+	}
+
 	try {
 		assert.doesNotThrow(fn, msg);
 	} catch (err) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -41,12 +41,26 @@ Test.prototype._assert = function () {
 
 Object.keys(assert).forEach(function (el) {
 	Test.prototype[el] = function () {
-		this._assert();
+		var self = this;
 
 		try {
-			assert[el].apply(assert, arguments);
+			var fn = assert[el].apply(assert, arguments);
+
+			if (fn && fn.then) {
+				fn
+					.then(function () {
+						self._assert();
+					})
+					.catch(function (err) {
+						self.assertError = err;
+						self._assert();
+					});
+			} else {
+				this._assert();
+			}
 		} catch (err) {
 			this.assertError = err;
+			this._assert();
 		}
 	};
 });

--- a/test/test.js
+++ b/test/test.js
@@ -136,7 +136,7 @@ test('handle falsy testing of objects', function (t) {
 	});
 });
 
-test('handle throws', function (t) {
+test('handle throws with error', function (t) {
 	ava(function (a) {
 		a.throws(function () {
 			throw new Error('foo');
@@ -149,10 +149,10 @@ test('handle throws', function (t) {
 	});
 });
 
-test('handle throws with error', function (t) {
+test('handle throws without error', function (t) {
 	ava(function (a) {
-		a.doesNotThrow(function () {
-			throw new Error('foo');
+		a.throws(function () {
+			return;
 		});
 
 		a.end();
@@ -162,7 +162,46 @@ test('handle throws with error', function (t) {
 	});
 });
 
-test('handle falsy throws', function (t) {
+test('handle throws with rejected promise', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.reject(new Error());
+		a.throws(promise);
+	}).run().then(function (a) {
+		t.false(a.assertError);
+		t.end();
+	});
+});
+
+test('handle throws with resolved promise', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.resolve();
+		a.throws(promise);
+	}).run().catch(function (err) {
+		t.is(err.name, 'AssertionError');
+		t.true(err);
+		t.end();
+	});
+});
+
+test('handle doesNotThrow with error', function (t) {
+	ava(function (a) {
+		a.doesNotThrow(function () {
+			throw new Error('foo');
+		});
+
+		a.end();
+	}).run().catch(function (err) {
+		t.is(err.name, 'AssertionError');
+		t.true(err);
+		t.end();
+	});
+});
+
+test('handle doesNotThrow without error', function (t) {
 	ava(function (a) {
 		a.doesNotThrow(function () {
 			return;
@@ -175,13 +214,24 @@ test('handle falsy throws', function (t) {
 	});
 });
 
-test('handle falsy throws with error', function (t) {
+test('handle doesNotThrow with resolved promise', function (t) {
 	ava(function (a) {
-		a.throws(function () {
-			return;
-		});
+		a.plan(1);
 
-		a.end();
+		var promise = Promise.resolve();
+		a.doesNotThrow(promise);
+	}).run().then(function (a) {
+		t.false(a.assertError);
+		t.end();
+	});
+});
+
+test('handle doesNotThrow with rejected promise', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.reject(new Error());
+		a.doesNotThrow(promise);
 	}).run().catch(function (err) {
 		t.true(err);
 		t.end();


### PR DESCRIPTION
This PR introduces the ability to handle promises in `t.throws()` and `t.doesNotThrow()` methods.

Refs #73.

Changes:

- In `lib/test.js` check, if assertion function returns promise and act accordingly
- Improve `t.throws()` and `t.doesNotThrow()` methods to handle promises
- Change test names related to functions above to be more clear

Let me know what you think ;)