### PR TITLE
Add support to t.plan() + promises

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -98,15 +98,21 @@ Test.prototype.run = function () {
 			var ret = this.fn(this);
 
 			if (ret && typeof ret.then === 'function') {
-				ret.then(this.exit.bind(this)).catch(function (err) {
-					this.assertError = new assert.AssertionError({
-						actual: err,
-						message: 'Promise rejected → ' + err,
-						operator: 'promise'
-					});
+				ret
+					.then(function () {
+						if (!this.planCount || this.planCount === this.assertCount) {
+							this.exit();
+						}
+					}.bind(this))
+					.catch(function (err) {
+						this.assertError = new assert.AssertionError({
+							actual: err,
+							message: 'Promise rejected → ' + err,
+							operator: 'promise'
+						});
 
-					this.exit();
-				}.bind(this));
+						this.exit();
+					}.bind(this));
 			}
 		} catch (err) {
 			this.assertError = err;

--- a/test/test.js
+++ b/test/test.js
@@ -62,6 +62,25 @@ test('plan assertions', function (t) {
 	});
 });
 
+test('plan assertions with support for promises', function (t) {
+	ava(function (a) {
+		a.plan(2);
+
+		var promise = Promise.resolve();
+
+		setTimeout(function () {
+			a.pass();
+			a.pass();
+		}, 200);
+
+		return promise;
+	}).run().then(function (a) {
+		t.is(a.planCount, 2);
+		t.is(a.assertCount, 2);
+		t.end();
+	});
+});
+
 test('run more assertions than planned', function (t) {
 	ava(function (a) {
 		a.plan(2);


### PR DESCRIPTION
This PR implements support to `t.plan()` + promises cocktail.

Fixes #75.

Example:

```js
test(function (t) {
  t.plan(1);

  var promise = Promise.resolve();

  setTimeout(function () {
    t.pass();
    // now test is finished
  }, 200);

  return promise;
});
```