### PR TITLE
Add fail-fast mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,7 +21,8 @@ var cli = meow({
 		'  ava <file|folder|glob> [...]',
 		'',
 		'Options',
-		'  --init  Add AVA to your project',
+		'  --init       Add AVA to your project',
+		'  --fail-fast  Stop after first test failure',
 		'',
 		'Examples',
 		'  ava',
@@ -34,7 +35,8 @@ var cli = meow({
 		'test.js test-*.js test/*.js'
 	]
 }, {
-	string: ['_']
+	string: ['_'],
+	boolean: ['fail-fast']
 });
 
 var fileCount = 0;
@@ -88,7 +90,13 @@ function test(data) {
 }
 
 function run(file) {
-	return fork(file)
+	var args = [file];
+
+	if (cli.flags.failFast) {
+		args.push('--fail-fast');
+	}
+
+	return fork(args)
 		.on('test', test)
 		.on('data', function (data) {
 			process.stdout.write(data);

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -7,15 +7,20 @@ var join = require('path').join;
 
 module.exports = fork;
 
-function fork(file) {
+function fork(args) {
+	if (!Array.isArray(args)) {
+		args = [args];
+	}
+
 	var babel = join(__dirname, 'babel.js');
+	var file = args[0];
 
 	var options = {
 		silent: true,
 		env: assign({}, process.env, {AVA_FORK: 1})
 	};
 
-	var ps = childProcess.fork(babel, [file], options);
+	var ps = childProcess.fork(babel, args, options);
 
 	var promise = new Promise(function (resolve, reject) {
 		ps.on('results', function (results) {

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,8 @@ $ ava --help
     ava <file|folder|glob> [...]
 
   Options
-    --init  Add AVA to your project
+    --init       Add AVA to your project
+    --fail-fast  Stop after first test failure
 
   Examples
     ava

--- a/test/fixture/fail-fast.js
+++ b/test/fixture/fail-fast.js
@@ -1,0 +1,11 @@
+import test from '../../';
+
+test(t => {
+	t.fail();
+	t.end();
+});
+
+test(t => {
+	t.pass();
+	t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,12 @@ var test = require('tape');
 var Runner = require('../lib/runner');
 var ava = require('../lib/test');
 
-function execCli(file, cb) {
-	childProcess.execFile('../cli.js', [file], {cwd: __dirname}, cb);
+function execCli(args, cb) {
+	if (!Array.isArray(args)) {
+		args = [args];
+	}
+
+	childProcess.execFile('../cli.js', args, {cwd: __dirname}, cb);
 }
 
 test('run test', function (t) {
@@ -720,7 +724,7 @@ test('wait for test to end', function (t) {
 test('display test title prefixes', function (t) {
 	t.plan(6);
 
-	execCli('fixture/*.js', function (err, stdout, stderr) {
+	execCli(['fixture/async-await.js', 'fixture/es2015.js', 'fixture/generators.js'], function (err, stdout, stderr) {
 		t.ifError(err);
 
 		// remove everything except test list
@@ -754,5 +758,19 @@ test('display test title prefixes', function (t) {
 		// if all lines were removed from expected output
 		// actual output matches expected output
 		t.is(tests.length, 0);
+	});
+});
+
+test('fail-fast mode', function (t) {
+	t.plan(5);
+
+	execCli(['fixture/fail-fast.js', '--fail-fast'], function (err, stdout, stderr) {
+		t.ok(err);
+		t.is(err.code, 1);
+
+		t.true(stderr.indexOf(figures.cross + ' [anonymous] false fail false') !== -1);
+		t.true(stderr.indexOf(figures.tick + ' [anonymous]') === -1);
+		t.true(stderr.indexOf('1 test failed') !== -1);
+		t.end();
 	});
 });


### PR DESCRIPTION
This PR adds `--fail-fast` option to exit after the first test failure.

Fixes #48.

Changes:
  - add `--fail-fast` option to `--help` output
  - add fail-fast mode
  - add tests