### PR TITLE
Run hooks only around tests

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -73,4 +73,3 @@ x.report = function (passed, failed) {
 		log.writelpad(chalk.green(passed, plur('test', passed), 'passed'));
 	}
 };
-

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,6 +4,8 @@ var EventEmitter = require('events').EventEmitter;
 var Promise = require('bluebird');
 var Test = require('./test');
 
+function noop() {}
+
 function each(items, fn) {
 	return Promise.all(items.map(fn));
 }
@@ -71,7 +73,7 @@ Runner.prototype.addAfterEachHook = function (title, cb) {
 	});
 };
 
-Runner.prototype._runTest = function (test) {
+Runner.prototype._runTestWithHooks = function (test) {
 	var self = this;
 
 	var beforeHooks = self.tests.beforeEach.map(function (hook) {
@@ -88,22 +90,26 @@ Runner.prototype._runTest = function (test) {
 	tests.push(test);
 	tests.push.apply(tests, afterHooks);
 
-	return eachSeries(tests, function (test) {
-		// add test result regardless of state
-		// but on error, don't execute next tests
-		return test.run()
-			.finally(function () {
-				self._addTestResult(test);
-			});
-	}).catch(function () {});
+	return eachSeries(tests, this._runTest.bind(this)).catch(noop);
+};
+
+Runner.prototype._runTest = function (test) {
+	var self = this;
+
+	// add test result regardless of state
+	// but on error, don't execute next tests
+	return test.run()
+		.finally(function () {
+			self._addTestResult(test);
+		});
 };
 
 Runner.prototype.concurrent = function (tests) {
-	return each(tests, this._runTest.bind(this));
+	return each(tests, this._runTestWithHooks.bind(this));
 };
 
 Runner.prototype.serial = function (tests) {
-	return eachSeries(tests, this._runTest.bind(this));
+	return eachSeries(tests, this._runTestWithHooks.bind(this));
 };
 
 Runner.prototype._addTestResult = function (test) {
@@ -125,7 +131,8 @@ Runner.prototype.run = function () {
 	var tests = this.tests;
 	var stats = this.stats;
 
-	return this.serial(tests.before)
+	return eachSeries(tests.before, this._runTest.bind(this))
+		.catch(noop)
 		.then(function () {
 			if (stats.failCount > 0) {
 				return Promise.reject();
@@ -138,11 +145,9 @@ Runner.prototype.run = function () {
 			return self.concurrent(tests.concurrent);
 		})
 		.then(function () {
-			return self.serial(tests.after);
+			return eachSeries(tests.after, self._runTest.bind(self));
 		})
-		.catch(function () {
-			return;
-		})
+		.catch(noop)
 		.then(function () {
 			stats.passCount = stats.testCount - stats.failCount;
 		});

--- a/test/test.js
+++ b/test/test.js
@@ -678,6 +678,43 @@ test('hooks - after each with serial tests', function (t) {
 	});
 });
 
+test('hooks - ensure hooks run only around tests', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addBeforeEachHook(function (a) {
+		arr.push('beforeEach');
+		a.end();
+	});
+
+	runner.addBeforeHook(function (a) {
+		arr.push('before');
+		a.end();
+	});
+
+	runner.addAfterEachHook(function (a) {
+		arr.push('afterEach');
+		a.end();
+	});
+
+	runner.addAfterHook(function (a) {
+		arr.push('after');
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		arr.push('test');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.same(arr, ['before', 'beforeEach', 'test', 'afterEach', 'after']);
+		t.end();
+	});
+});
+
 test('ES2015 support', function (t) {
 	t.plan(1);
 


### PR DESCRIPTION
This PR fixes #89.

Now AVA ensures that hooks run only around tests. Previously, hooks were running also around `before` and `after`, which is not quite good.