### PR TITLE
Fix t.throws() behavior to avoid false-positives and regex suport

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -70,19 +70,21 @@ x.notSame = function (val, expected, msg) {
 
 x.throws = function (fn, err, msg) {
 	if (fn && fn.then) {
-		err = err || Error;
+		var isFailed = false;
 
 		return fn
-			.catch(err, function (err) {
+			.catch(function (err) {
+				isFailed = true;
+
 				return err;
 			})
-			.then(function (value) {
-				if (value instanceof err) {
-					return;
+			.then(function (fnErr) {
+				if (!isFailed) {
+					x.throws(function () {}, err, msg);
 				}
 
 				x.throws(function () {
-					throw value;
+					throw fnErr;
 				}, err, msg);
 			});
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -204,8 +204,33 @@ test('handle throws with resolved promise', function (t) {
 		var promise = Promise.resolve();
 		a.throws(promise);
 	}).run().catch(function (err) {
-		t.is(err.name, 'AssertionError');
 		t.true(err);
+		t.is(err.name, 'AssertionError');
+		t.end();
+	});
+});
+
+test('handle throws with regex', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.reject(new Error('abc'));
+		a.throws(promise, /abc/);
+	}).run().then(function (a) {
+		t.false(a.assertionError);
+		t.end();
+	});
+});
+
+test('handle throws with false-positive promise', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.resolve(new Error());
+		a.throws(promise);
+	}).run().catch(function (err) {
+		t.true(err);
+		t.is(err.name, 'AssertionError');
 		t.end();
 	});
 });
@@ -218,8 +243,8 @@ test('handle doesNotThrow with error', function (t) {
 
 		a.end();
 	}).run().catch(function (err) {
-		t.is(err.name, 'AssertionError');
 		t.true(err);
+		t.is(err.name, 'AssertionError');
 		t.end();
 	});
 });
@@ -257,6 +282,7 @@ test('handle doesNotThrow with rejected promise', function (t) {
 		a.doesNotThrow(promise);
 	}).run().catch(function (err) {
 		t.true(err);
+		t.is(err.name, 'AssertionError');
 		t.end();
 	});
 });


### PR DESCRIPTION
This PR fixes #86 and fixes #85.

It improves `t.throws()`, so that it avoids false-positives results and supports regex, just like native `throws()`.