### PR TITLE
add xo coverage to the esnext fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && nyc tape test/*.js | tap-dot",
+    "test": "xo && xo --esnext true ./test/fixture/*.js && nyc tape test/*.js | tap-dot",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "files": [


### PR DESCRIPTION
I'm thinking of doing this for my own project `test` directories. The projects aren't `esnext` but the AVA tests are. 

This seemed more simple than implementing path-specific config in XO, and makes me feel better that I'm not lint-ignoring my tests.