### PR TITLE
Add serial mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,6 +23,7 @@ var cli = meow({
 		'Options',
 		'  --init       Add AVA to your project',
 		'  --fail-fast  Stop after first test failure',
+		'  --serial     Run tests serially',
 		'',
 		'Examples',
 		'  ava',
@@ -36,7 +37,7 @@ var cli = meow({
 	]
 }, {
 	string: ['_'],
-	boolean: ['fail-fast']
+	boolean: ['fail-fast', 'serial']
 });
 
 var fileCount = 0;
@@ -94,6 +95,10 @@ function run(file) {
 
 	if (cli.flags.failFast) {
 		args.push('--fail-fast');
+	}
+
+	if (cli.flags.serial) {
+		args.push('--serial');
 	}
 
 	return fork(args)

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,6 +4,8 @@ var EventEmitter = require('events').EventEmitter;
 var Promise = require('bluebird');
 var Test = require('./test');
 
+var isSerial = process.argv.indexOf('--serial') !== -1;
+
 function noop() {}
 
 function each(items, fn) {
@@ -105,6 +107,10 @@ Runner.prototype._runTest = function (test) {
 };
 
 Runner.prototype.concurrent = function (tests) {
+	if (isSerial) {
+		return this.serial(tests);
+	}
+
 	return each(tests, this._runTestWithHooks.bind(this));
 };
 

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,7 @@ $ ava --help
   Options
     --init       Add AVA to your project
     --fail-fast  Stop after first test failure
+    --serial     Run tests serially
 
   Examples
     ava
@@ -467,6 +468,14 @@ Have fun!
 ### Temp files
 
 Running tests concurrently comes with some challenges, doing IO is one. Usually, serial tests just create temp directories in the current test directory and cleans it up at the end. This won't work when you run tests concurrently as tests will conflict with each other. The correct way to do it is to use a new temp directory for each test. The [`tempfile`](https://github.com/sindresorhus/tempfile) and [`temp-write`](https://github.com/sindresorhus/temp-write) modules can be helpful.
+
+### Debugging
+
+AVA runs tests concurrently by default, which is suboptimal when you need to debug something. Instead, run tests serially with the `--serial` option:
+
+```
+$ ava --serial
+```
 
 
 ## FAQ

--- a/test/fixture/serial.js
+++ b/test/fixture/serial.js
@@ -1,0 +1,26 @@
+import test from '../../';
+
+function randomDelay() {
+	return parseInt(Math.random() * 1000, 10);
+}
+
+const tests = [];
+
+test('first', t => {
+	setTimeout(() => {
+		tests.push('first');
+		t.end();
+	}, randomDelay());
+});
+
+test('second', t => {
+	setTimeout(() => {
+		tests.push('second');
+		t.end();
+	}, randomDelay());
+});
+
+test(t => {
+	t.same(tests, ['first', 'second']);
+	t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -839,6 +839,15 @@ test('fail-fast mode', function (t) {
 	});
 });
 
+test('serial execution mode', function (t) {
+	t.plan(1);
+
+	execCli(['fixture/serial.js', '--serial'], function (err) {
+		t.ifError(err);
+		t.end();
+	});
+});
+
 test('power-assert support', function (t) {
 	t.plan(2);
 
@@ -853,6 +862,8 @@ test('power-assert support', function (t) {
 });
 
 test('change process.cwd() to a test\'s directory', function (t) {
+	t.plan(2);
+
 	execCli('fixture/process-cwd.js', function (err, stdout) {
 		t.ifError(err);
 		t.is(stdout.trim(), join(__dirname, 'fixture'));


### PR DESCRIPTION
This PR closes #31.

It adds `--serial` option, which forces AVA to run all tests serially by default.