### PR TITLE
Replace babel require hook with transformFileSync

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -1,11 +1,11 @@
 'use strict';
 var resolveFrom = require('resolve-from');
 var createEspowerPlugin = require('babel-plugin-espower/create');
+var requireFromString = require('require-from-string');
 var hasGenerators = parseInt(process.version.slice(1), 10) > 0;
 var path = process.argv[2];
 
 var options = {
-	only: path,
 	blacklist: hasGenerators ? ['regenerator'] : [],
 	optional: hasGenerators ? ['asyncToGenerator'] : [],
 	plugins: [
@@ -15,12 +15,14 @@ var options = {
 	]
 };
 
-try {
-	var localBabel = resolveFrom('.', 'babel-core/register') || resolveFrom('.', 'babel/register');
+var babel;
 
-	require(localBabel)(options);
+try {
+	var localBabel = resolveFrom('.', 'babel-core') || resolveFrom('.', 'babel');
+	babel = require(localBabel);
 } catch (err) {
-	require('babel-core/register')(options);
+	babel = require('babel-core');
 }
 
-require(path);
+var transpiled = babel.transformFileSync(path, options);
+requireFromString(transpiled.code, path);

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -7,7 +7,7 @@ var path = process.argv[2];
 
 var options = {
 	blacklist: hasGenerators ? ['regenerator'] : [],
-	optional: hasGenerators ? ['asyncToGenerator'] : [],
+	optional: hasGenerators ? ['asyncToGenerator', 'runtime'] : ['runtime'],
 	plugins: [
 		createEspowerPlugin(require('babel-core'), {
 			patterns: require('./enhance-assert').PATTERNS

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "babel-runtime": "^5.8.29",
     "bluebird": "^3.0.0",
     "chalk": "^1.0.0",
-    "co": "^4.6.0",
+    "co": "floatdrop/co#e6c2a50",
     "core-assert": "^0.1.0",
     "empower": "^1.0.2",
     "figures": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ava-init": "^0.1.0",
     "babel-core": "^5.8.23",
     "babel-plugin-espower": "^1.0.0",
+    "babel-runtime": "^5.8.29",
     "bluebird": "^3.0.0",
     "chalk": "^1.0.0",
     "co": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "power-assert-formatter": "^1.1.0",
     "power-assert-renderers": "^0.1.0",
     "pretty-ms": "^2.0.0",
+    "require-from-string": "^1.0.0",
     "resolve-from": "^1.0.0",
     "serialize-error": "^1.0.0",
     "set-immediate-shim": "^1.0.1",

--- a/test/fork.js
+++ b/test/fork.js
@@ -35,7 +35,7 @@ test('rejects on error and streams output', function (t) {
 			buffer += data;
 		})
 		.catch(function () {
-			t.ok(/Cannot find module/.test(buffer));
+			t.ok(/no such file or directory/.test(buffer));
 			t.end();
 		});
 });


### PR DESCRIPTION
Start of discussion - https://github.com/sindresorhus/ava/commit/52b0ccb33ca30bba5185056361f1c2976b7cf56f#commitcomment-13971327

If you have `babel` and want to use require hook in application code and want to run tests with `ava` - you can get syntax errors (`SyntaxError: Unexpected reserved word`) because babel will get options from `ava`. 