### PR TITLE
Shared context between tests and beforeEach/afterEach hooks

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -90,10 +90,20 @@ Runner.prototype._runTestWithHooks = function (test) {
 	tests.push(test);
 	tests.push.apply(tests, afterHooks);
 
-	return eachSeries(tests, this._runTest.bind(this)).catch(noop);
+	var context = {};
+
+	return eachSeries(tests, function (test) {
+		return this._runTest(test, context);
+	}.bind(this)).catch(noop);
 };
 
-Runner.prototype._runTest = function (test) {
+Runner.prototype._runTest = function (test, context) {
+	// shared context (only applies to tests with hooks around them)
+	// set only if `context` is an object (can be index number)
+	if (typeof context === 'object') {
+		test.context = context;
+	}
+
 	// add test result regardless of state
 	// but on error, don't execute next tests
 	return test.run()

--- a/lib/test.js
+++ b/lib/test.js
@@ -23,6 +23,7 @@ function Test(title, fn) {
 	this.assertCount = 0;
 	this.planCount = null;
 	this.duration = null;
+	this.context = {};
 
 	// store the time point before test execution
 	// to calculate the total time spent in test
@@ -105,7 +106,7 @@ Test.prototype.run = function () {
 		this._timeout = setTimeout(function () {}, TIMEOUT_MAX_VALUE);
 
 		try {
-			var ret = this.fn(this);
+			var ret = this.fn.call(this.context, this);
 
 			if (ret && typeof ret.then === 'function') {
 				ret

--- a/test/test.js
+++ b/test/test.js
@@ -742,6 +742,45 @@ test('hooks - ensure hooks run only around tests', function (t) {
 	});
 });
 
+test('hooks - shared context', function (t) {
+	t.plan(1);
+
+	var runner = new Runner();
+
+	runner.addBeforeHook(function (a) {
+		a.is(this.arr, undefined);
+		this.arr = [];
+		a.end();
+	});
+
+	runner.addAfterHook(function (a) {
+		a.is(this.arr, undefined);
+		a.end();
+	});
+
+	runner.addBeforeEachHook(function (a) {
+		this.arr = ['a'];
+		a.end();
+	});
+
+	runner.addTest(function (a) {
+		this.arr.push('b');
+		a.same(this.arr, ['a', 'b']);
+		a.end();
+	});
+
+	runner.addAfterEachHook(function (a) {
+		this.arr.push('c');
+		a.same(this.arr, ['a', 'b', 'c']);
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.is(runner.stats.failCount, 0);
+		t.end();
+	});
+});
+
 test('ES2015 support', function (t) {
 	t.plan(1);
 


### PR DESCRIPTION
This PR resolves the following use case:

```js
test.beforeEach(t => {
  this.data = generateUniqueData();
});

test('some data', t => {
  // use this.data
});
```

With this PR, context (`this` object) is shared between test and **beforeEach**/**afterEach** hooks (not **before** or **after**).