### PR TITLE
Forcibly kill every forked subprocess.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -158,7 +158,12 @@ function exit(results) {
 	// correctly flush the output when multiple test files
 	process.stdout.write('');
 
-	process.exit(failed > 0 ? 1 : 0);
+	// Individually kill each child process.
+	Promise.map(results, function (result) {
+		return result.kill();
+	}).finally(function () {
+		process.exit(failed > 0 ? 1 : 0);
+	});
 }
 
 function init(files) {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -18,13 +18,29 @@ module.exports = function (args) {
 
 	var ps = childProcess.fork(babel, args, options);
 
+	var killed = false;
+	var killedPromise = new Promise(function (resolve) {
+		ps.on('exit', function (code) {
+			killed = true;
+			resolve(code);
+		});
+	});
+
+	function kill() {
+		if (!killed) {
+			ps.kill();
+		}
+		return killedPromise;
+	}
+
 	var promise = new Promise(function (resolve, reject) {
 		ps.on('results', function (results) {
+			results.kill = kill;
 			resolve(results);
 		});
 
 		// reject only when forked process failed
-		ps.on('exit', function (code) {
+		killedPromise.then(function (code) {
 			if (code > 0) {
 				reject();
 			}

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -35,17 +35,18 @@ module.exports = function (args) {
 
 	var promise = new Promise(function (resolve, reject) {
 		ps.on('results', function (results) {
-			results.kill = kill;
 			resolve(results);
 		});
 
 		// reject only when forked process failed
-		killedPromise.then(function (code) {
+		ps.on('exit', function (code) {
 			if (code > 0) {
 				reject();
 			}
 		});
 	});
+
+	promise.kill = kill;
 
 	// emit `test` and `stats` events
 	ps.on('message', function (event) {

--- a/test/fixture/long-running.js
+++ b/test/fixture/long-running.js
@@ -1,0 +1,12 @@
+'use strict';
+const test = require('../../');
+
+test('long running', function (t) {
+	t.plan(1);
+
+	setTimeout(function () {
+		console.log('I\'m gonna live forever!!');
+	}, 15000);
+
+	t.ok(true);
+});

--- a/test/fork.js
+++ b/test/fork.js
@@ -43,11 +43,13 @@ test('rejects on error and streams output', function (t) {
 test('result.kill forcibly kills process', function (t) {
 	t.plan(1);
 	var start = Date.now();
-	fork(fixture('long-running.js'))
+	var promise = fork(fixture('long-running.js'))
 		.on('exit', function () {
 			t.ok(Date.now() - start < 10000);
-		})
-		.then(function (result) {
-			result.kill();
+		});
+
+	promise
+		.then(function () {
+			promise.kill();
 		});
 });

--- a/test/fork.js
+++ b/test/fork.js
@@ -39,3 +39,15 @@ test('rejects on error and streams output', function (t) {
 			t.end();
 		});
 });
+
+test('result.kill forcibly kills process', function (t) {
+	t.plan(1);
+	var start = Date.now();
+	fork(fixture('long-running.js'))
+		.on('exit', function () {
+			t.ok(Date.now() - start < 10000);
+		})
+		.then(function (result) {
+			result.kill();
+		});
+});


### PR DESCRIPTION
Killing the parent process skips execution of `end` listeners
on remaining forked child processes.

This interferes with `nyc` if processes are kept running after
test completion.

Refrence: https://github.com/bcoe/nyc/issues/52