### PR TITLE
Refactor promises in throws method

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -70,19 +70,11 @@ x.notSame = function (val, expected, msg) {
 
 x.throws = function (fn, err, msg) {
 	if (fn && fn.then) {
-		var isFailed = false;
-
 		return fn
-			.catch(function (err) {
-				isFailed = true;
-
-				return err;
+			.then(function () {
+				x.throws(function () {}, err, msg);
 			})
-			.then(function (fnErr) {
-				if (!isFailed) {
-					x.throws(function () {}, err, msg);
-				}
-
+			.catch(function (fnErr) {
 				x.throws(function () {
 					throw fnErr;
 				}, err, msg);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -73,8 +73,7 @@ x.throws = function (fn, err, msg) {
 		return fn
 			.then(function () {
 				x.throws(function () {}, err, msg);
-			})
-			.catch(function (fnErr) {
+			}, function (fnErr) {
 				x.throws(function () {
 					throw fnErr;
 				}, err, msg);


### PR DESCRIPTION
Regardless of issue https://github.com/sindresorhus/ava/issues/123, I think the promise code in `x.throws` might be written more cleaner.