### PR TITLE
Add string support to throws

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -90,7 +90,13 @@ x.throws = function (fn, err, msg) {
 	}
 
 	try {
-		assert.throws(fn, err, msg);
+		if (typeof err === 'string') {
+			assert.throws(fn, function (e) {
+				return e.message === err;
+			}, msg);
+		} else {
+			assert.throws(fn, err, msg);
+		}
 	} catch (err) {
 		test(false, create(err.actual, err.expected, err.operator, err.message, x.throws));
 	}

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -91,12 +91,13 @@ x.throws = function (fn, err, msg) {
 
 	try {
 		if (typeof err === 'string') {
-			assert.throws(fn, function (e) {
-				return e.message === err;
-			}, msg);
-		} else {
-			assert.throws(fn, err, msg);
+			var e = err;
+			err = function (err) {
+				return err.message === e;
+			};
 		}
+
+		assert.throws(fn, err, msg);
 	} catch (err) {
 		test(false, create(err.actual, err.expected, err.operator, err.message, x.throws));
 	}

--- a/readme.md
+++ b/readme.md
@@ -423,7 +423,7 @@ Assert that `value` is not deep equal to `expected`.
 
 Assert that `function` throws an error or `promise` rejects.
 
-`error` can be a constructor, regex or validation function.
+`error` can be a constructor, regex, error message or validation function.
 
 ### .doesNotThrow(function|promise, [message])
 

--- a/test/test.js
+++ b/test/test.js
@@ -223,6 +223,18 @@ test('handle throws with regex', function (t) {
 	});
 });
 
+test('handle throws with string', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.reject(new Error('abc'));
+		a.throws(promise, 'abc');
+	}).run().then(function (a) {
+		t.false(a.assertionError);
+		t.end();
+	});
+});
+
 test('handle throws with false-positive promise', function (t) {
 	ava(function (a) {
 		a.plan(1);


### PR DESCRIPTION
I added the possibility to pass in the error message as string to the `throws` method.

#### Example

```js
test('test it', t => {
	t.throws(throws, 'foo bar');
	t.end();

	function throws() {
		throw new Error('foo bar');
	}
});
```

#### Benefit
If you want to test the returned error message you either should use a regex or a validation function. The validation function spoils the test file in my opinion, and the regex is, well yeah, it's a regex. People have to escape some characters and a string just looks cleaner.

#### Downside
Not sure if it is a downside, but it's not standard `assert` stuff which might confuse people. Although, I don't really see it as downside, it's more an improvement.

// @sindresorhus @vdemedes @kevva @Qix- 