### PR TITLE
Throws returns the promise

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -53,7 +53,7 @@ Object.keys(assert).forEach(function (el) {
 			var fn = assert[el].apply(assert, arguments);
 
 			if (fn && fn.then) {
-				fn
+				return fn
 					.then(function () {
 						self._assert();
 					})
@@ -61,9 +61,9 @@ Object.keys(assert).forEach(function (el) {
 						self.assertError = err;
 						self._assert();
 					});
-			} else {
-				this._assert();
 			}
+
+			this._assert();
 		} catch (err) {
 			this.assertError = err;
 			this._assert();


### PR DESCRIPTION
Finally found the solution for #123 

By returning the promise, it's possible to check the throwed error like this which succesfully waits untill the promise is resolved/rejected.

```js
test(async t => {
	await t.throws(throws(), /hello world/);

	function throws() {
		return new Promise(function (resolve, reject) {
			setTimeout(function () {
				reject(new Error('hello world'));
			}, 2000);
		});
	}
});
```