### PR TITLE
Kill forked processes after tests are done

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -133,8 +133,7 @@ function sum(arr, key) {
 	return result;
 }
 
-function exit(testRun) {
-	var results = testRun.results;
+function exit(results) {
 	// assemble stats from all tests
 	var stats = results.map(function (result) {
 		return result.stats;
@@ -159,10 +158,7 @@ function exit(testRun) {
 	// correctly flush the output when multiple test files
 	process.stdout.write('');
 
-	// wait for the child processes to exit
-	testRun.childProcesses.finally(function () {
-		process.exit(failed > 0 ? 1 : 0);
-	});
+	process.exit(failed > 0 ? 1 : 0);
 }
 
 function init(files) {
@@ -182,14 +178,7 @@ function init(files) {
 
 			var tests = files.map(run);
 
-			return Promise.all(tests).then(function (results) {
-				return {
-					results: results,
-					childProcesses: Promise.map(tests, function (test) {
-						return test.kill();
-					})
-				};
-			});
+			return Promise.all(tests);
 		});
 }
 

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -18,35 +18,23 @@ module.exports = function (args) {
 
 	var ps = childProcess.fork(babel, args, options);
 
-	var killed = false;
-	var killedPromise = new Promise(function (resolve) {
-		ps.on('exit', function (code) {
-			killed = true;
-			resolve(code);
-		});
-	});
-
-	function kill() {
-		if (!killed) {
-			ps.kill();
-		}
-		return killedPromise;
-	}
-
 	var promise = new Promise(function (resolve, reject) {
 		ps.on('results', function (results) {
 			resolve(results);
+
+			// after all tests are finished and results received
+			// kill the forked process, so AVA can exit safely
+			ps.kill();
 		});
 
-		// reject only when forked process failed
+		ps.on('error', reject);
+
 		ps.on('exit', function (code) {
 			if (code > 0) {
 				reject();
 			}
 		});
 	});
-
-	promise.kill = kill;
 
 	// emit `test` and `stats` events
 	ps.on('message', function (event) {

--- a/test/fork.js
+++ b/test/fork.js
@@ -40,16 +40,13 @@ test('rejects on error and streams output', function (t) {
 		});
 });
 
-test('result.kill forcibly kills process', function (t) {
+test('exit after tests are finished', function (t) {
 	t.plan(1);
+
 	var start = Date.now();
-	var promise = fork(fixture('long-running.js'))
+
+	fork(fixture('long-running.js'))
 		.on('exit', function () {
 			t.ok(Date.now() - start < 10000);
-		});
-
-	promise
-		.then(function () {
-			promise.kill();
 		});
 });


### PR DESCRIPTION
@jamestalmage here's the refactored solution to the issue you mentioned - https://github.com/sindresorhus/ava/pull/134/files#diff-a48173105195b7a6481a3ad85b45144eR27.

The "trick" is to kill the forked process after the test results are received and not let `cli.js` handle this mess.