### PR TITLE
Use local babel in babel-plugin-espower

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -5,16 +5,6 @@ var requireFromString = require('require-from-string');
 var hasGenerators = parseInt(process.version.slice(1), 10) > 0;
 var path = process.argv[2];
 
-var options = {
-	blacklist: hasGenerators ? ['regenerator'] : [],
-	optional: hasGenerators ? ['asyncToGenerator', 'runtime'] : ['runtime'],
-	plugins: [
-		createEspowerPlugin(require('babel-core'), {
-			patterns: require('./enhance-assert').PATTERNS
-		})
-	]
-};
-
 var babel;
 
 try {
@@ -23,6 +13,16 @@ try {
 } catch (err) {
 	babel = require('babel-core');
 }
+
+var options = {
+	blacklist: hasGenerators ? ['regenerator'] : [],
+	optional: hasGenerators ? ['asyncToGenerator', 'runtime'] : ['runtime'],
+	plugins: [
+		createEspowerPlugin(babel, {
+			patterns: require('./enhance-assert').PATTERNS
+		})
+	]
+};
 
 var transpiled = babel.transformFileSync(path, options);
 requireFromString(transpiled.code, path);


### PR DESCRIPTION
Fix #129

Fix error that babel-plugin-espower resolves a different Babel version.

```
C:\Users\Frontend\AppData\Roaming\nvm\v0.12.5\node_modules\ava\node_modules\babel-core\lib\transformation\plugin.js:121
      throw new TypeError(messages.get("pluginNotFile", this.key));
            ^
TypeError: Plugin "babel-plugin-espower" is resolving to a different Babel version than what is performing the transform
ation.
    at Plugin.buildPass (C:\Users\Frontend\AppData\Roaming\nvm\v0.12.5\node_modules\ava\node_modules\babel-core\lib\tran
sformation\plugin.js:121:13)
    at PluginManager.add (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\transformation\file\plugin-manager.js:216:5
5)
    at File.buildTransformers (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\transformation\file\index.js:237:21)
    at new File (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\transformation\file\index.js:139:10)
    at Pipeline.transform (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\transformation\pipeline.js:164:16)
    at Object.transformFileSync (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\api\node.js:137:37)
    at compile (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\api\register\node.js:132:20)
    at normalLoader (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\api\register\node.js:199:14)
    at Object.require.extensions.(anonymous function) [as .js] (D:\Workflow\sandbox\aa\node_modules\babel-core\lib\api\r
egister\node.js:216:7)
    at Module.load (module.js:355:32)
TypeError: Cannot read property 'stack' of undefined
    at error (C:\Users\Frontend\AppData\Roaming\nvm\v0.12.5\node_modules\ava\cli.js:50:19)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
From previous event:
    at Object.<anonymous> (C:\Users\Frontend\AppData\Roaming\nvm\v0.12.5\node_modules\ava\cli.js:206:34)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```

This issue is reproduced when using a different version of local babel. https://github.com/sindresorhus/ava/issues/129#issuecomment-154602231