### PR TITLE
Remove runtime from lib/babel

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -16,7 +16,7 @@ try {
 
 var options = {
 	blacklist: hasGenerators ? ['regenerator'] : [],
-	optional: hasGenerators ? ['asyncToGenerator', 'runtime'] : ['runtime'],
+	optional: hasGenerators ? ['asyncToGenerator'] : [],
 	plugins: [
 		createEspowerPlugin(babel, {
 			patterns: require('./enhance-assert').PATTERNS

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -2,6 +2,8 @@
 var resolveFrom = require('resolve-from');
 var createEspowerPlugin = require('babel-plugin-espower/create');
 var requireFromString = require('require-from-string');
+var fs = require('fs');
+var join = require('path').join;
 var hasGenerators = parseInt(process.version.slice(1), 10) > 0;
 var path = process.argv[2];
 
@@ -25,4 +27,10 @@ var options = {
 };
 
 var transpiled = babel.transformFileSync(path, options);
+
+if (!hasGenerators) {
+	var runtime = fs.readFileSync(join(__dirname, '/regeneratorRuntime.js'));
+	transpiled.code = runtime + '\n' + transpiled.code;
+}
+
 requireFromString(transpiled.code, path);

--- a/lib/regeneratorRuntime.js
+++ b/lib/regeneratorRuntime.js
@@ -1,0 +1,904 @@
+var Promise = (function () {
+	var PENDING = 'pending';
+	var SETTLED = 'settled';
+	var FULFILLED = 'fulfilled';
+	var REJECTED = 'rejected';
+	var NOOP = function () {};
+
+	var asyncSetTimer = typeof setImmediate === 'undefined' ?  setTimeout : setImmediate;
+	var asyncQueue = [];
+	var asyncTimer;
+
+	function asyncFlush() {
+		// run promise callbacks
+		for (var i = 0; i < asyncQueue.length; i++) {
+			asyncQueue[i][0](asyncQueue[i][1]);
+		}
+
+		// reset async asyncQueue
+		asyncQueue = [];
+		asyncTimer = false;
+	}
+
+	function asyncCall(callback, arg) {
+		asyncQueue.push([callback, arg]);
+
+		if (!asyncTimer) {
+			asyncTimer = true;
+			asyncSetTimer(asyncFlush, 0);
+		}
+	}
+
+	function invokeResolver(resolver, promise) {
+		function resolvePromise(value) {
+			resolve(promise, value);
+		}
+
+		function rejectPromise(reason) {
+			reject(promise, reason);
+		}
+
+		try {
+			resolver(resolvePromise, rejectPromise);
+		} catch (e) {
+			rejectPromise(e);
+		}
+	}
+
+	function invokeCallback(subscriber) {
+		var owner = subscriber.owner;
+		var settled = owner._state;
+		var value = owner._data;
+		var callback = subscriber[settled];
+		var promise = subscriber.then;
+
+		if (typeof callback === 'function') {
+			settled = FULFILLED;
+			try {
+				value = callback(value);
+			} catch (e) {
+				reject(promise, e);
+			}
+		}
+
+		if (!handleThenable(promise, value)) {
+			if (settled === FULFILLED) {
+				resolve(promise, value);
+			}
+
+			if (settled === REJECTED) {
+				reject(promise, value);
+			}
+		}
+	}
+
+	function handleThenable(promise, value) {
+		var resolved;
+
+		try {
+			if (promise === value) {
+				throw new TypeError('A promises callback cannot return that same promise.');
+			}
+
+			if (value && (typeof value === 'function' || typeof value === 'object')) {
+				var then = value.then; // then should be retrived only once
+
+				if (typeof then === 'function') {
+					then.call(value, function (val) {
+						if (!resolved) {
+							resolved = true;
+
+							if (value !== val) {
+								resolve(promise, val);
+							} else {
+								fulfill(promise, val);
+							}
+						}
+					}, function (reason) {
+						if (!resolved) {
+							resolved = true;
+
+							reject(promise, reason);
+						}
+					});
+
+					return true;
+				}
+			}
+		} catch (e) {
+			if (!resolved) {
+				reject(promise, e);
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	function resolve(promise, value) {
+		if (promise === value || !handleThenable(promise, value)) {
+			fulfill(promise, value);
+		}
+	}
+
+	function fulfill(promise, value) {
+		if (promise._state === PENDING) {
+			promise._state = SETTLED;
+			promise._data = value;
+
+			asyncCall(publishFulfillment, promise);
+		}
+	}
+
+	function reject(promise, reason) {
+		if (promise._state === PENDING) {
+			promise._state = SETTLED;
+			promise._data = reason;
+
+			asyncCall(publishRejection, promise);
+		}
+	}
+
+	function publish(promise) {
+		promise._then = promise._then.forEach(invokeCallback);
+	}
+
+	function publishFulfillment(promise) {
+		promise._state = FULFILLED;
+		publish(promise);
+	}
+
+	function publishRejection(promise) {
+		promise._state = REJECTED;
+		publish(promise);
+	}
+
+	/**
+	* @class
+	*/
+	function Promise(resolver) {
+		if (typeof resolver !== 'function') {
+			throw new TypeError('Promise resolver ' + resolver + ' is not a function');
+		}
+
+		if (this instanceof Promise === false) {
+			throw new TypeError('Failed to construct \'Promise\': Please use the \'new\' operator, this object constructor cannot be called as a function.');
+		}
+
+		this._then = [];
+
+		invokeResolver(resolver, this);
+	}
+
+	Promise.prototype = {
+		constructor: Promise,
+
+		_state: PENDING,
+		_then: null,
+		_data: undefined,
+
+		then: function (onFulfillment, onRejection) {
+			var subscriber = {
+				owner: this,
+				then: new this.constructor(NOOP),
+				fulfilled: onFulfillment,
+				rejected: onRejection
+			};
+
+			if (this._state === FULFILLED || this._state === REJECTED) {
+				// already resolved, call callback async
+				asyncCall(invokeCallback, subscriber);
+			} else {
+				// subscribe
+				this._then.push(subscriber);
+			}
+
+			return subscriber.then;
+		},
+
+		'catch': function (onRejection) {
+			return this.then(null, onRejection);
+		}
+	};
+
+	Promise.all = function (promises) {
+		if (!Array.isArray(promises)) {
+			throw new TypeError('You must pass an array to Promise.all().');
+		}
+
+		return new Promise(function (resolve, reject) {
+			var results = [];
+			var remaining = 0;
+
+			function resolver(index) {
+				remaining++;
+				return function (value) {
+					results[index] = value;
+					if (!--remaining) {
+						resolve(results);
+					}
+				};
+			}
+
+			for (var i = 0, promise; i < promises.length; i++) {
+				promise = promises[i];
+
+				if (promise && typeof promise.then === 'function') {
+					promise.then(resolver(i), reject);
+				} else {
+					results[i] = promise;
+				}
+			}
+
+			if (!remaining) {
+				resolve(results);
+			}
+		});
+	};
+
+	Promise.race = function (promises) {
+		if (!Array.isArray(promises)) {
+			throw new TypeError('You must pass an array to Promise.race().');
+		}
+
+		return new Promise(function (resolve, reject) {
+			for (var i = 0, promise; i < promises.length; i++) {
+				promise = promises[i];
+
+				if (promise && typeof promise.then === 'function') {
+					promise.then(resolve, reject);
+				} else {
+					resolve(promise);
+				}
+			}
+		});
+	};
+
+	Promise.resolve = function (value) {
+		if (value && typeof value === 'object' && value.constructor === Promise) {
+			return value;
+		}
+
+		return new Promise(function (resolve) {
+			resolve(value);
+		});
+	};
+
+	Promise.reject = function (reason) {
+		return new Promise(function (resolve, reject) {
+			reject(reason);
+		});
+	};
+
+	return Promise;
+})();
+
+/**
+* Copyright (c) 2014, Facebook, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* https://raw.github.com/facebook/regenerator/master/LICENSE file. An
+* additional grant of patent rights can be found in the PATENTS file in
+* the same directory.
+*/
+
+var regeneratorRuntime = (function () {
+	var hasOwn = Object.prototype.hasOwnProperty;
+	var undefined; // More compressible than void 0.
+	var iteratorSymbol =
+	typeof Symbol === "function" && Symbol.iterator || "@@iterator";
+
+	var runtime = {};
+
+	function wrap(innerFn, outerFn, self, tryLocsList) {
+		// If outerFn provided, then outerFn.prototype instanceof Generator.
+		var generator = Object.create((outerFn || Generator).prototype);
+		var context = new Context(tryLocsList || []);
+
+		// The ._invoke method unifies the implementations of the .next,
+		// .throw, and .return methods.
+		generator._invoke = makeInvokeMethod(innerFn, self, context);
+
+		return generator;
+	}
+	runtime.wrap = wrap;
+
+	// Try/catch helper to minimize deoptimizations. Returns a completion
+	// record like context.tryEntries[i].completion. This interface could
+	// have been (and was previously) designed to take a closure to be
+	// invoked without arguments, but in all the cases we care about we
+	// already have an existing method we want to call, so there's no need
+	// to create a new function object. We can even get away with assuming
+	// the method takes exactly one argument, since that happens to be true
+	// in every case, so we don't have to touch the arguments object. The
+	// only additional allocation required is the completion record, which
+	// has a stable shape and so hopefully should be cheap to allocate.
+	function tryCatch(fn, obj, arg) {
+		try {
+			return { type: "normal", arg: fn.call(obj, arg) };
+		} catch (err) {
+			return { type: "throw", arg: err };
+		}
+	}
+
+	var GenStateSuspendedStart = "suspendedStart";
+	var GenStateSuspendedYield = "suspendedYield";
+	var GenStateExecuting = "executing";
+	var GenStateCompleted = "completed";
+
+	// Returning this object from the innerFn has the same effect as
+	// breaking out of the dispatch switch statement.
+	var ContinueSentinel = {};
+
+	// Dummy constructor functions that we use as the .constructor and
+	// .constructor.prototype properties for functions that return Generator
+	// objects. For full spec compliance, you may wish to configure your
+	// minifier not to mangle the names of these two functions.
+	function Generator() {}
+	function GeneratorFunction() {}
+	function GeneratorFunctionPrototype() {}
+
+	var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype;
+	GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+	GeneratorFunctionPrototype.constructor = GeneratorFunction;
+	GeneratorFunction.displayName = "GeneratorFunction";
+
+	// Helper for defining the .next, .throw, and .return methods of the
+	// Iterator interface in terms of a single ._invoke method.
+	function defineIteratorMethods(prototype) {
+		["next", "throw", "return"].forEach(function(method) {
+			prototype[method] = function(arg) {
+				return this._invoke(method, arg);
+			};
+		});
+	}
+
+	runtime.isGeneratorFunction = function(genFun) {
+		var ctor = typeof genFun === "function" && genFun.constructor;
+		return ctor
+		? ctor === GeneratorFunction ||
+		// For the native GeneratorFunction constructor, the best we can
+		// do is to check its .name property.
+		(ctor.displayName || ctor.name) === "GeneratorFunction"
+		: false;
+	};
+
+	runtime.mark = function(genFun) {
+		if (Object.setPrototypeOf) {
+			Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+		} else {
+			genFun.__proto__ = GeneratorFunctionPrototype;
+		}
+		genFun.prototype = Object.create(Gp);
+		return genFun;
+	};
+
+	// Within the body of any async function, `await x` is transformed to
+	// `yield regeneratorRuntime.awrap(x)`, so that the runtime can test
+	// `value instanceof AwaitArgument` to determine if the yielded value is
+	// meant to be awaited. Some may consider the name of this method too
+	// cutesy, but they are curmudgeons.
+	runtime.awrap = function(arg) {
+		return new AwaitArgument(arg);
+	};
+
+	function AwaitArgument(arg) {
+		this.arg = arg;
+	}
+
+	function AsyncIterator(generator) {
+		// This invoke function is written in a style that assumes some
+		// calling function (or Promise) will handle exceptions.
+		function invoke(method, arg) {
+			var result = generator[method](arg);
+			var value = result.value;
+			return value instanceof AwaitArgument
+			? Promise.resolve(value.arg).then(invokeNext, invokeThrow)
+			: Promise.resolve(value).then(function(unwrapped) {
+				// When a yielded Promise is resolved, its final value becomes
+				// the .value of the Promise<{value,done}> result for the
+				// current iteration. If the Promise is rejected, however, the
+				// result for this iteration will be rejected with the same
+				// reason. Note that rejections of yielded Promises are not
+				// thrown back into the generator function, as is the case
+				// when an awaited Promise is rejected. This difference in
+				// behavior between yield and await is important, because it
+				// allows the consumer to decide what to do with the yielded
+				// rejection (swallow it and continue, manually .throw it back
+				// into the generator, abandon iteration, whatever). With
+				// await, by contrast, there is no opportunity to examine the
+				// rejection reason outside the generator function, so the
+				// only option is to throw it from the await expression, and
+				// let the generator function handle the exception.
+				result.value = unwrapped;
+				return result;
+			});
+		}
+
+		if (typeof process === "object" && process.domain) {
+			invoke = process.domain.bind(invoke);
+		}
+
+		var invokeNext = invoke.bind(generator, "next");
+		var invokeThrow = invoke.bind(generator, "throw");
+		var invokeReturn = invoke.bind(generator, "return");
+		var previousPromise;
+
+		function enqueue(method, arg) {
+			function callInvokeWithMethodAndArg() {
+				return invoke(method, arg);
+			}
+
+			return previousPromise =
+			// If enqueue has been called before, then we want to wait until
+			// all previous Promises have been resolved before calling invoke,
+			// so that results are always delivered in the correct order. If
+			// enqueue has not been called before, then it is important to
+			// call invoke immediately, without waiting on a callback to fire,
+			// so that the async generator function has the opportunity to do
+			// any necessary setup in a predictable way. This predictability
+			// is why the Promise constructor synchronously invokes its
+			// executor callback, and why async functions synchronously
+			// execute code before the first await. Since we implement simple
+			// async functions in terms of async generators, it is especially
+			// important to get this right, even though it requires care.
+			previousPromise ? previousPromise.then(
+				callInvokeWithMethodAndArg,
+				// Avoid propagating failures to Promises returned by later
+				// invocations of the iterator.
+				callInvokeWithMethodAndArg
+			) : new Promise(function (resolve) {
+				resolve(callInvokeWithMethodAndArg());
+			});
+		}
+
+		// Define the unified helper method that is used to implement .next,
+		// .throw, and .return (see defineIteratorMethods).
+		this._invoke = enqueue;
+	}
+
+	defineIteratorMethods(AsyncIterator.prototype);
+
+	// Note that simple async functions are implemented on top of
+	// AsyncIterator objects; they just return a Promise for the value of
+	// the final result produced by the iterator.
+	runtime.async = function(innerFn, outerFn, self, tryLocsList) {
+		var iter = new AsyncIterator(
+			wrap(innerFn, outerFn, self, tryLocsList)
+		);
+
+		return runtime.isGeneratorFunction(outerFn)
+		? iter // If outerFn is a generator, return the full iterator.
+		: iter.next().then(function(result) {
+			return result.done ? result.value : iter.next();
+		});
+	};
+
+	function makeInvokeMethod(innerFn, self, context) {
+		var state = GenStateSuspendedStart;
+
+		return function invoke(method, arg) {
+			if (state === GenStateExecuting) {
+				throw new Error("Generator is already running");
+			}
+
+			if (state === GenStateCompleted) {
+				if (method === "throw") {
+					throw arg;
+				}
+
+				// Be forgiving, per 25.3.3.3.3 of the spec:
+				// https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generatorresume
+				return doneResult();
+			}
+
+			while (true) {
+				var delegate = context.delegate;
+				if (delegate) {
+					if (method === "return" ||
+					(method === "throw" && delegate.iterator[method] === undefined)) {
+						// A return or throw (when the delegate iterator has no throw
+						// method) always terminates the yield* loop.
+						context.delegate = null;
+
+						// If the delegate iterator has a return method, give it a
+						// chance to clean up.
+						var returnMethod = delegate.iterator["return"];
+						if (returnMethod) {
+							var record = tryCatch(returnMethod, delegate.iterator, arg);
+							if (record.type === "throw") {
+								// If the return method threw an exception, let that
+								// exception prevail over the original return or throw.
+								method = "throw";
+								arg = record.arg;
+								continue;
+							}
+						}
+
+						if (method === "return") {
+							// Continue with the outer return, now that the delegate
+							// iterator has been terminated.
+							continue;
+						}
+					}
+
+					var record = tryCatch(
+						delegate.iterator[method],
+						delegate.iterator,
+						arg
+					);
+
+					if (record.type === "throw") {
+						context.delegate = null;
+
+						// Like returning generator.throw(uncaught), but without the
+						// overhead of an extra function call.
+						method = "throw";
+						arg = record.arg;
+						continue;
+					}
+
+					// Delegate generator ran and handled its own exceptions so
+					// regardless of what the method was, we continue as if it is
+					// "next" with an undefined arg.
+					method = "next";
+					arg = undefined;
+
+					var info = record.arg;
+					if (info.done) {
+						context[delegate.resultName] = info.value;
+						context.next = delegate.nextLoc;
+					} else {
+						state = GenStateSuspendedYield;
+						return info;
+					}
+
+					context.delegate = null;
+				}
+
+				if (method === "next") {
+					if (state === GenStateSuspendedYield) {
+						context.sent = arg;
+					} else {
+						context.sent = undefined;
+					}
+
+				} else if (method === "throw") {
+					if (state === GenStateSuspendedStart) {
+						state = GenStateCompleted;
+						throw arg;
+					}
+
+					if (context.dispatchException(arg)) {
+						// If the dispatched exception was caught by a catch block,
+						// then let that catch block handle the exception normally.
+						method = "next";
+						arg = undefined;
+					}
+
+				} else if (method === "return") {
+					context.abrupt("return", arg);
+				}
+
+				state = GenStateExecuting;
+
+				var record = tryCatch(innerFn, self, context);
+				if (record.type === "normal") {
+					// If an exception is thrown from innerFn, we leave state ===
+					// GenStateExecuting and loop back for another invocation.
+					state = context.done
+					? GenStateCompleted
+					: GenStateSuspendedYield;
+
+					var info = {
+						value: record.arg,
+						done: context.done
+					};
+
+					if (record.arg === ContinueSentinel) {
+						if (context.delegate && method === "next") {
+							// Deliberately forget the last sent value so that we don't
+							// accidentally pass it on to the delegate.
+							arg = undefined;
+						}
+					} else {
+						return info;
+					}
+
+				} else if (record.type === "throw") {
+					state = GenStateCompleted;
+					// Dispatch the exception by looping back around to the
+					// context.dispatchException(arg) call above.
+					method = "throw";
+					arg = record.arg;
+				}
+			}
+		};
+	}
+
+	// Define Generator.prototype.{next,throw,return} in terms of the
+	// unified ._invoke helper method.
+	defineIteratorMethods(Gp);
+
+	Gp[iteratorSymbol] = function() {
+		return this;
+	};
+
+	Gp.toString = function() {
+		return "[object Generator]";
+	};
+
+	function pushTryEntry(locs) {
+		var entry = { tryLoc: locs[0] };
+
+		if (1 in locs) {
+			entry.catchLoc = locs[1];
+		}
+
+		if (2 in locs) {
+			entry.finallyLoc = locs[2];
+			entry.afterLoc = locs[3];
+		}
+
+		this.tryEntries.push(entry);
+	}
+
+	function resetTryEntry(entry) {
+		var record = entry.completion || {};
+		record.type = "normal";
+		delete record.arg;
+		entry.completion = record;
+	}
+
+	function Context(tryLocsList) {
+		// The root entry object (effectively a try statement without a catch
+		// or a finally block) gives us a place to store values thrown from
+		// locations where there is no enclosing try statement.
+		this.tryEntries = [{ tryLoc: "root" }];
+		tryLocsList.forEach(pushTryEntry, this);
+		this.reset(true);
+	}
+
+	runtime.keys = function(object) {
+		var keys = [];
+		for (var key in object) {
+			keys.push(key);
+		}
+		keys.reverse();
+
+		// Rather than returning an object with a next method, we keep
+		// things simple and return the next function itself.
+		return function next() {
+			while (keys.length) {
+				var key = keys.pop();
+				if (key in object) {
+					next.value = key;
+					next.done = false;
+					return next;
+				}
+			}
+
+			// To avoid creating an additional object, we just hang the .value
+			// and .done properties off the next function object itself. This
+			// also ensures that the minifier will not anonymize the function.
+			next.done = true;
+			return next;
+		};
+	};
+
+	function values(iterable) {
+		if (iterable) {
+			var iteratorMethod = iterable[iteratorSymbol];
+			if (iteratorMethod) {
+				return iteratorMethod.call(iterable);
+			}
+
+			if (typeof iterable.next === "function") {
+				return iterable;
+			}
+
+			if (!isNaN(iterable.length)) {
+				var i = -1, next = function next() {
+					while (++i < iterable.length) {
+						if (hasOwn.call(iterable, i)) {
+							next.value = iterable[i];
+							next.done = false;
+							return next;
+						}
+					}
+
+					next.value = undefined;
+					next.done = true;
+
+					return next;
+				};
+
+				return next.next = next;
+			}
+		}
+
+		// Return an iterator with no values.
+		return { next: doneResult };
+	}
+	runtime.values = values;
+
+	function doneResult() {
+		return { value: undefined, done: true };
+	}
+
+	Context.prototype = {
+		constructor: Context,
+
+		reset: function(skipTempReset) {
+			this.prev = 0;
+			this.next = 0;
+			this.sent = undefined;
+			this.done = false;
+			this.delegate = null;
+
+			this.tryEntries.forEach(resetTryEntry);
+
+			if (!skipTempReset) {
+				for (var name in this) {
+					// Not sure about the optimal order of these conditions:
+					if (name.charAt(0) === "t" &&
+					hasOwn.call(this, name) &&
+					!isNaN(+name.slice(1))) {
+						this[name] = undefined;
+					}
+				}
+			}
+		},
+
+		stop: function() {
+			this.done = true;
+
+			var rootEntry = this.tryEntries[0];
+			var rootRecord = rootEntry.completion;
+			if (rootRecord.type === "throw") {
+				throw rootRecord.arg;
+			}
+
+			return this.rval;
+		},
+
+		dispatchException: function(exception) {
+			if (this.done) {
+				throw exception;
+			}
+
+			var context = this;
+			function handle(loc, caught) {
+				record.type = "throw";
+				record.arg = exception;
+				context.next = loc;
+				return !!caught;
+			}
+
+			for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+				var entry = this.tryEntries[i];
+				var record = entry.completion;
+
+				if (entry.tryLoc === "root") {
+					// Exception thrown outside of any try block that could handle
+					// it, so set the completion value of the entire function to
+					// throw the exception.
+					return handle("end");
+				}
+
+				if (entry.tryLoc <= this.prev) {
+					var hasCatch = hasOwn.call(entry, "catchLoc");
+					var hasFinally = hasOwn.call(entry, "finallyLoc");
+
+					if (hasCatch && hasFinally) {
+						if (this.prev < entry.catchLoc) {
+							return handle(entry.catchLoc, true);
+						} else if (this.prev < entry.finallyLoc) {
+							return handle(entry.finallyLoc);
+						}
+
+					} else if (hasCatch) {
+						if (this.prev < entry.catchLoc) {
+							return handle(entry.catchLoc, true);
+						}
+
+					} else if (hasFinally) {
+						if (this.prev < entry.finallyLoc) {
+							return handle(entry.finallyLoc);
+						}
+
+					} else {
+						throw new Error("try statement without catch or finally");
+					}
+				}
+			}
+		},
+
+		abrupt: function(type, arg) {
+			for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+				var entry = this.tryEntries[i];
+				if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) {
+					var finallyEntry = entry;
+					break;
+				}
+			}
+
+			if (finallyEntry && (type === "break" || type === "continue") && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc) {
+				// Ignore the finally entry if control is not jumping to a
+				// location outside the try/catch block.
+				finallyEntry = null;
+			}
+
+			var record = finallyEntry ? finallyEntry.completion : {};
+			record.type = type;
+			record.arg = arg;
+
+			if (finallyEntry) {
+				this.next = finallyEntry.finallyLoc;
+			} else {
+				this.complete(record);
+			}
+
+			return ContinueSentinel;
+		},
+
+		complete: function(record, afterLoc) {
+			if (record.type === "throw") {
+				throw record.arg;
+			}
+
+			if (record.type === "break" ||
+			record.type === "continue") {
+				this.next = record.arg;
+			} else if (record.type === "return") {
+				this.rval = record.arg;
+				this.next = "end";
+			} else if (record.type === "normal" && afterLoc) {
+				this.next = afterLoc;
+			}
+		},
+
+		finish: function(finallyLoc) {
+			for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+				var entry = this.tryEntries[i];
+				if (entry.finallyLoc === finallyLoc) {
+					this.complete(entry.completion, entry.afterLoc);
+					resetTryEntry(entry);
+					return ContinueSentinel;
+				}
+			}
+		},
+
+		"catch": function(tryLoc) {
+			for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+				var entry = this.tryEntries[i];
+				if (entry.tryLoc === tryLoc) {
+					var record = entry.completion;
+					if (record.type === "throw") {
+						var thrown = record.arg;
+						resetTryEntry(entry);
+					}
+					return thrown;
+				}
+			}
+
+			// The context.catch method must only be called with a location
+			// argument that corresponds to a known catch block.
+			throw new Error("illegal catch attempt");
+		},
+
+		delegateYield: function(iterable, resultName, nextLoc) {
+			this.delegate = {
+				iterator: values(iterable),
+				resultName: resultName,
+				nextLoc: nextLoc
+			};
+
+			return ContinueSentinel;
+		}
+	};
+
+	return runtime;
+})();

--- a/package.json
+++ b/package.json
@@ -94,5 +94,10 @@
     "tap-dot": "^1.0.0",
     "tape": "^4.0.0",
     "xo": "*"
+  },
+  "xo": {
+    "ignores": [
+      "lib/regeneratorRuntime.js"
+    ]
   }
 }


### PR DESCRIPTION
Fixes for #144 

- [x] Remove `runtime` with polyfills
- [x] Add `regenerator` to test files
- [ ] Make it less horrible