### PR TITLE
Add ava modules to test module paths

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -2,9 +2,9 @@
 var resolveFrom = require('resolve-from');
 var createEspowerPlugin = require('babel-plugin-espower/create');
 var requireFromString = require('require-from-string');
-var hasGenerators = parseInt(process.version.slice(1), 10) > 0;
-var path = process.argv[2];
 
+var hasGenerators = parseInt(process.version.slice(1), 10) > 0;
+var testPath = process.argv[2];
 var babel;
 
 try {
@@ -24,5 +24,7 @@ var options = {
 	]
 };
 
-var transpiled = babel.transformFileSync(path, options);
-requireFromString(transpiled.code, path);
+var transpiled = babel.transformFileSync(testPath, options);
+requireFromString(transpiled.code, testPath, {
+	appendPaths: module.paths
+});

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "power-assert-formatter": "^1.3.0",
     "power-assert-renderers": "^0.1.0",
     "pretty-ms": "^2.0.0",
-    "require-from-string": "^1.0.0",
+    "require-from-string": "^1.1.0",
     "resolve-from": "^1.0.0",
     "serialize-error": "^1.0.0",
     "set-immediate-shim": "^1.0.1",


### PR DESCRIPTION
Drawback - now you can require any module from `ava/node_module` in tests.

Closes #144