### PR TITLE
WIP: Improve babel runtime lookup

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -1,22 +1,30 @@
 'use strict';
-var resolveFrom = require('resolve-from');
+var unsafeResolveFrom = require('resolve-from');
 var createEspowerPlugin = require('babel-plugin-espower/create');
 var requireFromString = require('require-from-string');
+var path = require('path');
 var hasGenerators = parseInt(process.version.slice(1), 10) > 0;
-var path = process.argv[2];
+var testFile = process.argv[2];
 
-var babel;
-
-try {
-	var localBabel = resolveFrom('.', 'babel-core') || resolveFrom('.', 'babel');
-	babel = require(localBabel);
-} catch (err) {
-	babel = require('babel-core');
+function resolveFrom(dir, p) {
+	try {
+		return unsafeResolveFrom(dir, p);
+	} catch (e) {}
 }
+
+var babelPath = resolveFrom('.', 'babel-core') || resolveFrom('.', 'babel') || require.resolve('babel-core');
+var babel = require(babelPath);
+
+var rtp1 = 'babel-runtime/regenerator';
+var rtp2 = 'regenerator/runtime-module';
+var rtp3 = 'babel-core/node_modules/regenerator/runtime-module';
+var babelDir = path.dirname(babelPath);
+var runtimePath = resolveFrom('.', rtp1) || resolveFrom('.', rtp2) || resolveFrom('.', rtp3) || resolveFrom(babelDir, rtp1) || resolveFrom(babelDir, rtp2) || resolveFrom(babelDir, rtp3) || require.resolve(rtp1);
+var bluebirdPath = require.resolve('bluebird');
 
 var options = {
 	blacklist: hasGenerators ? ['regenerator'] : [],
-	optional: hasGenerators ? ['asyncToGenerator', 'runtime'] : ['runtime'],
+	optional: hasGenerators ? ['asyncToGenerator'] : [],
 	plugins: [
 		createEspowerPlugin(babel, {
 			patterns: require('./enhance-assert').PATTERNS
@@ -24,5 +32,16 @@ var options = {
 	]
 };
 
-var transpiled = babel.transformFileSync(path, options);
-requireFromString(transpiled.code, path);
+var transpiled = babel.transformFileSync(testFile, options);
+
+var code = [
+	'var regeneratorRuntime=require("',
+	runtimePath,
+	'"); var Promise=require("',
+	bluebirdPath,
+	'"); (function(){',
+	transpiled.code,
+	'})()'
+].join('');
+
+requireFromString(code, testFile);


### PR DESCRIPTION
Attempts to address #152 

It needs a bit more testing / follow up (I think there are a couple extra `requireFrom`s in there).

Submitted for feedback.

Instead of mucking with module paths, it finds the dependencies and builds some wrapper code that will require them with absolute paths (pretty straightforward)

The difficult part is making sure we get module resolution correct.

Basically, the way I see it there can be a few things happening:

 1. User has `babel-runtime` installed locally
 2. User has `regenerator` installed locally.
 3. User has `babel-core` installed locally
 4. User has `babel` installed locally
 5. User has nothing installed and will rely on the local ava implementation.

Here is what we should then resolve

1.  `babel-runtime/regenerator` from `.`
2.  `regenerator/runtime-module` from `.`
3.  `regenerator/runtime-module` from `node_modeules/babel-core`
4.  deeply nested at this point: `n_m/babel/n_m/babel-core/n_m/regenerator/runtime-module` (`n_m === node_modules`)

And who knows how `npm dedupe` has flattened things (some of those deeply nested items may get promoted to higher level folders by the dedupe process).

