### PR TITLE
Fix Windows onExit failure.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -158,7 +158,10 @@ function exit(results) {
 	// correctly flush the output when multiple test files
 	process.stdout.write('');
 
-	process.exit(failed > 0 ? 1 : 0);
+	// timeout required to correctly flush stderr on Node 0.10 Windows
+	setTimeout(function () {
+		process.exit(failed > 0 ? 1 : 0);
+	}, 0);
 }
 
 function init(files) {

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -28,3 +28,9 @@ var transpiled = babel.transformFileSync(testPath, options);
 requireFromString(transpiled.code, testPath, {
 	appendPaths: module.paths
 });
+
+process.on('message', function (message) {
+	if (message['ava-kill-command']) {
+		process.exit(0);
+	}
+});

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -26,7 +26,7 @@ module.exports = function (args) {
 
 			// after all tests are finished and results received
 			// kill the forked process, so AVA can exit safely
-			ps.kill();
+			ps.send({'ava-kill-command': true});
 		});
 
 		ps.on('error', reject);

--- a/test/fork.js
+++ b/test/fork.js
@@ -48,8 +48,8 @@ test('exit after tests are finished', function (t) {
 
 	fork(fixture('long-running.js'))
 		.on('exit', function () {
-			t.ok(Date.now() - start < 10000, 'did NOT wait for setTimeout(fn, 15000');
-			t.ok(cleanupCompleted, 'did wait for onExit(fn) to complete');
+			t.ok(Date.now() - start < 10000, 'should NOT wait for setTimeout(fn, 15000)');
+			t.ok(cleanupCompleted, 'should wait for onExit(fn) to complete');
 		})
 		.on('cleanup-completed', function (event) {
 			cleanupCompleted = event.completed;

--- a/test/fork.js
+++ b/test/fork.js
@@ -48,8 +48,8 @@ test('exit after tests are finished', function (t) {
 
 	fork(fixture('long-running.js'))
 		.on('exit', function () {
-			t.ok(Date.now() - start < 10000, 'should NOT wait for setTimeout(fn, 15000)');
-			t.ok(cleanupCompleted, 'should wait for onExit(fn) to complete');
+			t.ok(Date.now() - start < 10000, 'test waited for a pending setTimeout');
+			t.ok(cleanupCompleted, 'cleanup did not complete');
 		})
 		.on('cleanup-completed', function (event) {
 			cleanupCompleted = event.completed;

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ function execCli(args, cb) {
 		args = [args];
 	}
 
-	childProcess.execFile('../cli.js', args, {cwd: __dirname}, cb);
+	childProcess.execFile(process.execPath, ['../cli.js'].concat(args), {cwd: __dirname}, cb);
 }
 
 test('run test', function (t) {


### PR DESCRIPTION
SIGHUP seems to be the only kill signal supported by Windows:
https://nodejs.org/api/process.html#process_process_kill_pid_signal

This is a stab in the dark while I wade through setting up Node on Windows.
