### PR TITLE
test() should throw if no callback is provided. Fixes #172

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -18,6 +18,8 @@ function Test(title, fn) {
 		title = null;
 	}
 
+	assert.is(typeof fn, 'function', 'you must provide a callback');
+
 	this.title = title || fnName(fn) || '[anonymous]';
 	this.fn = isGenerator(fn) ? co.wrap(fn) : fn;
 	this.assertCount = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,16 @@ test('test title is optional', function (t) {
 	});
 });
 
+test('test callback is required', function (t) {
+	t.throws(function () {
+		ava();
+	}, /you must provide a callback/);
+	t.throws(function () {
+		ava('title');
+	}, /you must provide a callback/);
+	t.end();
+});
+
 test('infer test name from function', function (t) {
 	ava(function foo(a) {
 		a.end();


### PR DESCRIPTION
#172