### PR TITLE
made "concurernvy vs. parallelism" section clearer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -520,7 +520,13 @@ AVA, not Ava or ava. Pronounced [`/ˈeɪvə/` ay-və](media/pronunciation.m4a?ra
 
 ### Concurrency vs. parallelism
 
-Concurrency is not parallelism. It enables parallelism. It's about dealing with, while parallelism is about doing, lots of things at once.
+Concurrency is not parallelism. It enables parallelism.
+
+**Concurrency** is when two tasks can start, run, and complete in overlapping time periods. It doesn't necessarily mean they'll ever both be running at the same instant. (e.g. multitasking on a single-core machine.) 
+
+**Parallelism** is when tasks literally run at the same time. (e.g. on a multicore processor.)
+
+[(Source)](http://stackoverflow.com/a/1050257)
 
 
 ## Support

--- a/readme.md
+++ b/readme.md
@@ -520,7 +520,7 @@ AVA, not Ava or ava. Pronounced [`/ˈeɪvə/` ay-və](media/pronunciation.m4a?ra
 
 ### Concurrency vs. parallelism
 
-Concurrency is not parallelism. It enables parallelism. To learn more about the difference, see [this](http://stackoverflow.com/a/1050257) Stack Overflow answer. 
+Concurrency is not parallelism. It enables parallelism. To learn more about the difference, see [this](http://stackoverflow.com/q/1050222) Stack Overflow answer. 
 
 
 ## Support

--- a/readme.md
+++ b/readme.md
@@ -522,7 +522,7 @@ AVA, not Ava or ava. Pronounced [`/ˈeɪvə/` ay-və](media/pronunciation.m4a?ra
 
 Concurrency is not parallelism. It enables parallelism.
 
-**Concurrency** is when two tasks can start, run, and complete in overlapping time periods. It doesn't necessarily mean they'll ever both be running at the same instant. (e.g. multitasking on a single-core machine.) 
+**Concurrency** is when two or more tasks can start, run, and complete in overlapping time periods. It doesn't necessarily mean they'll ever both be running at the same instant. (e.g. multitasking on a single-core machine.) 
 
 **Parallelism** is when tasks literally run at the same time. (e.g. on a multicore processor.)
 

--- a/readme.md
+++ b/readme.md
@@ -520,13 +520,7 @@ AVA, not Ava or ava. Pronounced [`/ˈeɪvə/` ay-və](media/pronunciation.m4a?ra
 
 ### Concurrency vs. parallelism
 
-Concurrency is not parallelism. It enables parallelism.
-
-**Concurrency** is when two or more tasks can start, run, and complete in overlapping time periods. It doesn't necessarily mean they'll ever both be running at the same instant. (e.g. multitasking on a single-core machine.) 
-
-**Parallelism** is when tasks literally run at the same time. (e.g. on a multicore processor.)
-
-[(Source)](http://stackoverflow.com/a/1050257)
+Concurrency is not parallelism. It enables parallelism. To learn more about the difference, see [this](http://stackoverflow.com/a/1050257) Stack Overflow answer. 
 
 
 ## Support


### PR DESCRIPTION
For many people, the concept of concurrency vs. parallelism can be hard to grok.

I do not think the old descriptin read very well, nor did I think it would be _that_ helpful to someone who needed the answer in the frirst place (i.e. someone who doesn't know the difference.)

I tried writing an answer of my own before I realized that someone else had already put it best, so I quoted an aclaimed StackOverflow answer and gave appropiate credit (as Creative Commons requires).

I think linking to a SO question will also make it easy for people to read other answers, which they may understand better.