### PR TITLE
Display only failed hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,13 @@ var isFailed = false;
 
 Error.stackTraceLimit = Infinity;
 
-function test(err, title, duration) {
+function test(err, title, duration, type) {
 	if (isFailed) {
+		return;
+	}
+
+	// don't display anything, if it's a passed hook
+	if (!err && type !== 'test') {
 		return;
 	}
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -53,14 +53,25 @@ Runner.prototype.addSerialTest = function (title, cb) {
 };
 
 Runner.prototype.addBeforeHook = function (title, cb) {
-	this.tests.before.push(new Test(title, cb));
+	var test = new Test(title, cb);
+	test.type = 'hook';
+
+	this.tests.before.push(test);
 };
 
 Runner.prototype.addAfterHook = function (title, cb) {
-	this.tests.after.push(new Test(title, cb));
+	var test = new Test(title, cb);
+	test.type = 'hook';
+
+	this.tests.after.push(test);
 };
 
 Runner.prototype.addBeforeEachHook = function (title, cb) {
+	if (!cb) {
+		cb = title;
+		title = undefined;
+	}
+
 	this.tests.beforeEach.push({
 		title: title,
 		fn: cb
@@ -68,6 +79,11 @@ Runner.prototype.addBeforeEachHook = function (title, cb) {
 };
 
 Runner.prototype.addAfterEachHook = function (title, cb) {
+	if (!cb) {
+		cb = title;
+		title = undefined;
+	}
+
 	this.tests.afterEach.push({
 		title: title,
 		fn: cb
@@ -76,11 +92,19 @@ Runner.prototype.addAfterEachHook = function (title, cb) {
 
 Runner.prototype._runTestWithHooks = function (test) {
 	var beforeHooks = this.tests.beforeEach.map(function (hook) {
-		return new Test(hook.title, hook.fn);
+		var title = hook.title || 'beforeEach for "' + test.title + '"';
+		hook = new Test(title, hook.fn);
+		hook.type = 'eachHook';
+
+		return hook;
 	});
 
 	var afterHooks = this.tests.afterEach.map(function (hook) {
-		return new Test(hook.title, hook.fn);
+		var title = hook.title || 'afterEach for "' + test.title + '"';
+		hook = new Test(title, hook.fn);
+		hook.type = 'eachHook';
+
+		return hook;
 	});
 
 	var tests = [];
@@ -137,10 +161,11 @@ Runner.prototype._addTestResult = function (test) {
 	this.results.push({
 		duration: test.duration,
 		title: test.title,
-		error: test.assertError
+		error: test.assertError,
+		type: test.type
 	});
 
-	this.emit('test', test.assertError, test.title, test.duration);
+	this.emit('test', test.assertError, test.title, test.duration, test.type);
 };
 
 Runner.prototype.run = function () {

--- a/lib/test.js
+++ b/lib/test.js
@@ -13,7 +13,7 @@ function Test(title, fn) {
 		return new Test(title, fn);
 	}
 
-	if (typeof title !== 'string') {
+	if (typeof title === 'function') {
 		fn = title;
 		title = null;
 	}
@@ -26,6 +26,9 @@ function Test(title, fn) {
 	this.planCount = null;
 	this.duration = null;
 	this.context = {};
+
+	// test type, can be: test, hook, eachHook
+	this.type = 'test';
 
 	// store the time point before test execution
 	// to calculate the total time spent in test

--- a/test/fixture/hooks-failing.js
+++ b/test/fixture/hooks-failing.js
@@ -1,0 +1,13 @@
+const test = require('../../');
+
+test.beforeEach(fail);
+test(pass);
+
+function pass(t) {
+	t.end();
+}
+
+function fail(t) {
+	t.fail();
+	t.end();
+}

--- a/test/fixture/hooks-passing.js
+++ b/test/fixture/hooks-passing.js
@@ -1,0 +1,11 @@
+const test = require('../../');
+
+test.before(pass);
+test.beforeEach(pass);
+test.after(pass);
+test.afterEach(pass);
+test(pass);
+
+function pass(t) {
+	t.end();
+}


### PR DESCRIPTION
This PR fixes #105.

From now on, AVA displays only hooks that failed. This results to a dramatically cleaner output:

**Before**:

<img width="275" alt="screen shot 2015-11-11 at 5 04 02 pm" src="https://cloud.githubusercontent.com/assets/697676/11095626/3cd398ba-8896-11e5-9645-e4b5a58b60bd.png">

**After**:

<img width="261" alt="screen shot 2015-11-11 at 5 04 30 pm" src="https://cloud.githubusercontent.com/assets/697676/11095641/4ee37e26-8896-11e5-8e22-5d85aa0d4985.png">
