### PR TITLE
Add test.skip()

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,3 +77,4 @@ module.exports.before = runner.addBeforeHook.bind(runner);
 module.exports.after = runner.addAfterHook.bind(runner);
 module.exports.beforeEach = runner.addBeforeEachHook.bind(runner);
 module.exports.afterEach = runner.addAfterEachHook.bind(runner);
+module.exports.skip = runner.addSkippedTest.bind(runner);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -39,6 +39,11 @@ x.test = function (props) {
 		return;
 	}
 
+	if (props.skip) {
+		log.write('  ' + chalk.cyan('- ' + props.title));
+		return;
+	}
+
 	// if (runner.stats.testCount === 1) {
 	// 	return;
 	// }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -90,7 +90,19 @@ Runner.prototype.addAfterEachHook = function (title, cb) {
 	});
 };
 
+Runner.prototype.addSkippedTest = function (title, cb) {
+	var test = new Test(title, cb);
+	test.skip = true;
+
+	this.tests.concurrent.push(test);
+};
+
 Runner.prototype._runTestWithHooks = function (test) {
+	if (test.skip) {
+		this._addTestResult(test);
+		return Promise.resolve();
+	}
+
 	var beforeHooks = this.tests.beforeEach.map(function (hook) {
 		var title = hook.title || 'beforeEach for "' + test.title + '"';
 		hook = new Test(title, hook.fn);
@@ -162,7 +174,8 @@ Runner.prototype._addTestResult = function (test) {
 		duration: test.duration,
 		title: test.title,
 		error: test.assertError,
-		type: test.type
+		type: test.type,
+		skip: test.skip
 	};
 
 	this.results.push(props);

--- a/test/test.js
+++ b/test/test.js
@@ -857,6 +857,30 @@ test('test types and titles', function (t) {
 	runner.run().then(t.end);
 });
 
+test('skip test', function (t) {
+	t.plan(3);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addTest(function (a) {
+		arr.push('a');
+		a.end();
+	});
+
+	runner.addSkippedTest(function (a) {
+		arr.push('b');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.is(runner.stats.testCount, 1);
+		t.is(runner.stats.passCount, 1);
+		t.same(arr, ['a']);
+		t.end();
+	});
+});
+
 test('ES2015 support', function (t) {
 	t.plan(1);
 


### PR DESCRIPTION
This PR fixes #192.

It allows you to use `test.skip()` to skip the whole test. The output for skipped tests is like that:

<img width="231" alt="screen shot 2015-11-11 at 9 16 46 pm" src="https://cloud.githubusercontent.com/assets/697676/11101873/9066300a-88b9-11e5-92f8-e565df9c14e2.png">
