### PR TITLE
(don't merge): Demonstrate problematic async with t.end as callback.

### DIFF
--- a/test/fixture/problematic-async-await-with-end.js
+++ b/test/fixture/problematic-async-await-with-end.js
@@ -1,0 +1,20 @@
+'use strict';
+const test = require('../../');
+
+test('async function that should fail', async function (t) {
+	const value = await Promise.resolve(1);
+
+	t.is(value, 1);
+
+	equalInTheFuture(value, 2, t.end);
+});
+
+function equalInTheFuture(a, b, cb) {
+	setTimeout(() => {
+		if (a === b) {
+			return cb();
+		} else {
+			cb(new Error(`Uh oh, McFly! ${a} !== ${b}`));
+		}
+	}, 200);
+}


### PR DESCRIPTION
I have found a potentially problematic usage scenarios as it relates to #181.

We support returning promises as a way to end the test, and also encourage the use of async functions (which are simply transpiled to return Promieses anyway).

In PR #181 we are close to allowing `t.end` to be used as a callback.

The sample fixture in this PR illustrates the problem.

Using an async function, but passing `t.end` as a callback to some method that will not call the callback with an error until sometime after the promise resolves may mean the forked process has been forcibly killed already and we have a false pass.

I'm not sure how to handle this.

Possibly use a property getter for `t.end` that flags when the property has been accessed, and disables Promise resolution as a way to end the test? (though that could lead to a really confusing situation as well).