### PR TITLE
fork.js: Reject child-process completion promise with an error.

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -33,7 +33,7 @@ module.exports = function (args) {
 
 		ps.on('exit', function (code) {
 			if (code > 0 && code !== 143) {
-				reject();
+				reject(new Error(file + ' exited with a non-zero exit code: ' + code));
 			} else {
 				resolve(testResults);
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -1057,7 +1057,9 @@ test('change process.cwd() to a test\'s directory', function (t) {
 });
 
 test('Babel require hook only applies to the test file', function (t) {
-	execCli('fixture/babel-hook.js', function (err) {
+	execCli('fixture/babel-hook.js', function (err, stdout, stderr) {
+		t.ok(/exited with a non-zero exit code/.test(stderr));
+		t.ok(/Unexpected token/.test(stdout));
 		t.ok(err);
 		t.is(err.code, 1);
 		t.end();


### PR DESCRIPTION
It is generally recommended to reject Promises with an error.
This becomes especially true with the move to `async/await`,
as `Promise.reject(1)` essentially becomes `throw 1` in that context.

Not doing so was causing a weird bug on Node 0.10.

Ref: https://travis-ci.org/sindresorhus/ava/jobs/90709377#L779