### PR TITLE
Implement the only modifier.

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,3 +79,4 @@ module.exports.after = runner.addAfterHook.bind(runner);
 module.exports.beforeEach = runner.addBeforeEachHook.bind(runner);
 module.exports.afterEach = runner.addAfterEachHook.bind(runner);
 module.exports.skip = runner.addSkippedTest.bind(runner);
+module.exports.only = runner.addOnlyTest.bind(runner);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -97,6 +97,9 @@ Runner.prototype.addSkippedTest = function (title, cb) {
 	this.tests.concurrent.push(test);
 };
 
+Runner.prototype.addOnlyTest = function () {
+};
+
 Runner.prototype._runTestWithHooks = function (test) {
 	if (test.skip) {
 		this._addTestResult(test);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -32,6 +32,7 @@ function Runner(opts) {
 	this.tests = {
 		concurrent: [],
 		serial: [],
+		only: [],
 		before: [],
 		after: [],
 		beforeEach: [],
@@ -97,7 +98,9 @@ Runner.prototype.addSkippedTest = function (title, cb) {
 	this.tests.concurrent.push(test);
 };
 
-Runner.prototype.addOnlyTest = function () {
+Runner.prototype.addOnlyTest = function (title, cb) {
+	this.stats.testCount++;
+	this.tests.only.push(new Test(title, cb));
 };
 
 Runner.prototype._runTestWithHooks = function (test) {
@@ -206,16 +209,20 @@ Runner.prototype.run = function () {
 			}
 		})
 		.then(function () {
-			return self.serial(tests.serial);
+			return self.concurrent(tests.only);
 		})
 		.then(function () {
-			return self.concurrent(tests.concurrent);
+			return tests.only.length ? [] : self.serial(tests.serial);
+		})
+		.then(function () {
+			return tests.only.length ? [] : self.concurrent(tests.concurrent);
 		})
 		.then(function () {
 			return eachSeries(tests.after, self._runTest.bind(self));
 		})
 		.catch(noop)
 		.then(function () {
+			stats.testCount = tests.only.length ? tests.only.length : stats.testCount;
 			stats.passCount = stats.testCount - stats.failCount;
 		});
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1034,6 +1034,30 @@ test('skip test', function (t) {
 	});
 });
 
+test('only test', function (t) {
+	t.plan(3);
+
+	var runner = new Runner();
+	var arr = [];
+
+	runner.addTest(function (a) {
+		arr.push('a');
+		a.end();
+	});
+
+	runner.addOnlyTest(function (a) {
+		arr.push('b');
+		a.end();
+	});
+
+	runner.run().then(function () {
+		t.is(runner.stats.testCount, 1);
+		t.is(runner.stats.passCount, 1);
+		t.same(arr, ['b']);
+		t.end();
+	});
+});
+
 test('ES2015 support', function (t) {
 	t.plan(1);
 


### PR DESCRIPTION
**DO NOT MERGE**

Resolve #132 

I hack the test count number to show the *right* number and passed cases number. From my understand, such information should be pass through the promise chain.

Besides, `ava.serial.only` has no support in this PR yet.

/cc @vdemedes @sindresorhus

---

Screenshot:

![screenshot_2015-11-12_23-48-19](https://cloud.githubusercontent.com/assets/1296500/11122835/e9d793d4-8997-11e5-86d0-bff5c3cc1374.png)
