### PR TITLE
regression: logger throws on files with both passing and failing tests.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -58,7 +58,7 @@ x.errors = function (results) {
 	var i = 0;
 
 	results.forEach(function (result) {
-		if (!result.error) {
+		if (!(result.error && result.error.message)) {
 			return;
 		}
 

--- a/test/fixture/one-pass-one-fail.js
+++ b/test/fixture/one-pass-one-fail.js
@@ -1,0 +1,11 @@
+const test = require('../../');
+
+test('this is a passing test', t => {
+	t.ok(true);
+	t.end();
+});
+
+test('this is a failing test', t => {
+	t.ok(false);
+	t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1075,3 +1075,15 @@ test('absolute paths in CLI', function (t) {
 		t.end();
 	});
 });
+
+test('titles of both passing and failing tests and AssertionErrors are displayed', function (t) {
+	t.plan(4);
+
+	execCli('fixture/one-pass-one-fail.js', function (err, stdout, stderr) {
+		t.ok(err);
+		t.ok(/this is a passing test/.test(stderr));
+		t.ok(/this is a failing test/.test(stderr));
+		t.ok(/AssertionError/.test(stderr));
+		t.end();
+	});
+});


### PR DESCRIPTION
log.errors() cycles through all the results from a file (passing and failing)
and prints out a summary of the failing tests and the assertion errors.

It was misidentfying all results as errors, and then throwing
when result.error turned out to be an empty object ({}).

I think the result object can be improved such that
result.error === false when there were no errors.
But that is for another PR.