### PR TITLE
ignore non test files, fixes #209

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -132,6 +132,10 @@ function sum(arr, key) {
 }
 
 function exit(results) {
+	// in case of non-test files, the result will be undefined so we remove them
+	results = results.filter(function (result) {
+		return result !== undefined;
+	});
 	// assemble stats from all tests
 	var stats = results.map(function (result) {
 		return result.stats;

--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ function exit() {
 	});
 }
 
+process.send({
+	name: 'started',
+	data: {}
+});
+
 setImmediate(function () {
 	runner.on('test', test);
 	runner.run().then(exit);

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -25,8 +25,14 @@ var options = {
 };
 
 var transpiled = babel.transformFileSync(testPath, options);
+
 requireFromString(transpiled.code, testPath, {
 	appendPaths: module.paths
+});
+
+process.send({
+	name: 'babel-ended',
+	data: {}
 });
 
 process.on('message', function (message) {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -17,6 +17,7 @@ module.exports = function (args) {
 	};
 
 	var ps = childProcess.fork(babel, args, options);
+	var isTestFile = false;
 
 	var promise = new Promise(function (resolve, reject) {
 		var testResults;
@@ -31,6 +32,13 @@ module.exports = function (args) {
 
 		ps.on('error', reject);
 
+		// if babel ended but ava was not imported, we can safely exit
+		ps.on('babel-ended', function () {
+			if (!isTestFile) {
+				ps.send({'ava-kill-command': true});
+			}
+		});
+
 		ps.on('exit', function (code) {
 			if (code > 0 && code !== 143) {
 				reject(new Error(file + ' exited with a non-zero exit code: ' + code));
@@ -40,11 +48,16 @@ module.exports = function (args) {
 		});
 	});
 
-	// emit `test` and `stats` events
+	// emit 'started', `test` and `stats` events
 	ps.on('message', function (event) {
 		event.data.file = file;
 
 		ps.emit(event.name, event.data);
+	});
+
+	// when ava is imported this event is emitted runs  so we know it is a test file
+	ps.on('started', function () {
+		isTestFile = true;
 	});
 
 	// emit data events on forked process' output

--- a/test/fixture/non-test-file.js
+++ b/test/fixture/non-test-file.js
@@ -1,0 +1,1 @@
+//nothing here!

--- a/test/test.js
+++ b/test/test.js
@@ -1087,3 +1087,13 @@ test('titles of both passing and failing tests and AssertionErrors are displayed
 		t.end();
 	});
 });
+
+test('ignore non-test files', function (t) {
+	t.plan(2);
+
+	execCli([path.resolve('.', 'test/fixture/non-test-file.js')], function (err, stdout, stderr) {
+		t.ifError(err);
+		t.is(stderr.trim(), '0 tests passed');
+		t.end();
+	});
+});


### PR DESCRIPTION
I took a long shot with this PR but hopefully it helps :)

This fix has 2 parts:

1) When a file that didn't include AVA ran inside the babel.js child  process the process will never exit as no piece of code will ever emit the needed events. 
The only way I found around this, because of the complex process nature of the code, is to send a message once AVA runs on a file, and another message when babel finishes. The result is that inside fork.js we can now know if a file that did not include AVA was read and exit if so.
PS: this only happens in master, not in v0.4.2, probably because the fix in [here](https://github.com/sindresorhus/ava/commit/6a8f0e7a7caf833627c4645e74f8632e1c0c02b8)

2) If a file didn't include AVA, test results are not emitted and thus an the error in the mentioned issue is is thrown. I filtered the all undefined results to fix this.

Also, added a test that will fail on master / latest published version.