### PR TITLE
Make AppVeyor retry failed runs.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
-  - npm -g install npm@latest
+  - npm -g install npm@latest || (timeout 30 && npm -g install npm@latest)
   - set PATH=%APPDATA%\npm;%PATH%
-  - npm install
+  - npm install || (timeout 30 && npm install)
 matrix:
   fast_finish: true
 build: off
@@ -19,4 +19,4 @@ clone_depth: 1
 test_script:
   - node --version
   - npm --version
-  - npm run test-win
+  - npm run test-win || (timeout 30 && npm run test-win)


### PR DESCRIPTION
Tests are just too brittle on AppVeyor. `npm install` fails frequently,
and Node on Windows does not seem to reliably flush stdout/stderr
of forked child processes.

I don't like this, but I'm at a loss for other solutions.