### PR TITLE
add support for *.spec.js spec file naming

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -64,9 +64,16 @@ function prefixTitle(file) {
 	base += path.sep;
 
 	var prefix = path.relative(process.cwd(), file)
-		.replace(/test\-/g, '')
+		.replace(base, '');
+
+	if (/\.spec\./.test(prefix)) {
+		prefix = prefix.replace(/\.spec\./, '.');
+	} else {
+		prefix = prefix.replace(/test\-/g, '');
+	}
+
+	prefix = prefix
 		.replace(/\.js$/, '')
-		.replace(base, '')
 		.split(path.sep).join(separator);
 
 	if (prefix.length > 0) {


### PR DESCRIPTION
This change adds support for `whatever.spec.js` test file names (in the context of prefixing test results by the CLI) which is a quite common practice really. The former logic which trims `test-` prefixes stays in place.

```
test-whatever.js => whatever
test-whatever.spec.js => test-whatever
```

It might even make sense to include support for the `whateverSpec.js` variation.