### PR TITLE
simplify context sharing between beforeEach and test

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -125,18 +125,15 @@ Runner.prototype._runTestWithHooks = function (test) {
 	tests.push(test);
 	tests.push.apply(tests, afterHooks);
 
-	// wrapper to allow context to be a primitive value
-	var contextWrapper = {
-		context: {}
-	};
+	var context = {};
 
 	return eachSeries(tests, function (test) {
 		Object.defineProperty(test, 'context', {
 			get: function () {
-				return contextWrapper.context;
+				return context;
 			},
 			set: function (val) {
-				contextWrapper.context = val;
+				context = val;
 			}
 		});
 


### PR DESCRIPTION
The wrapper is not necessary, even for primitives.

// @sindresorhus 