### PR TITLE
cause build to fail if `tape` exits with a non-zero exit code

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && nyc tape test/*.js | tap-spec",
-    "test-win": "tape test/*.js | tap-spec",
+    "test": "xo && nyc tape test/*.js | tap-spec; test \"${PIPESTATUS[0]} -eq 0\"",
+    "test-win": "tape test/*.js | tap-spec; test \"${PIPESTATUS[0]} -eq 0\"",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "files": [


### PR DESCRIPTION
This is the only solution I have found so far.

Demonstration of the issue: #230

This is a known problem: https://github.com/scottcorgan/tap-spec/issues/40

Note that this does not work on Windows. The build will still exhibit false positives on Windows. I added it to the `test-win` script only because I often use that as a shortcut to skip the linter. It does not interfere with operation on Windows.