### PR TITLE
Document workaround for transpiling ES2015 module imports in tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -313,7 +313,7 @@ You can also use your own local Babel version:
 
 #### Transpiling Dependent Modules
 
-AVA currently only transpiles the tests that you ask it to run.  *It will not transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES2015 and/or use the ES2015 module syntax).*  While there are valid reasons for taking this approach, it may not be what you expect!
+AVA currently only transpiles the tests that you ask it to run.  *It will not transpile modules that you ```import``` from outside of the test.*  While there are valid reasons for taking this approach, it may not be what you expect!
 
 As a simple workaround, you can use [Babel's require hook](https://babeljs.io/docs/usage/require/) in order to do on-the-fly transpiling of modules that are subsequently required.  Because AVA supports ES6 module syntax, you can use it to import the require hook itself:
 

--- a/readme.md
+++ b/readme.md
@@ -311,14 +311,16 @@ You can also use your own local Babel version:
 }
 ```
 
-*Note:  AVA currently only transpiles the tests that you ask it to run.  In other words, it won't transitively transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES6 and/or use the ES6 module syntax).  While there are valid reasons for taking this approach (no impact/modification to the code under test), it may not be what you expect!*
+#### Transpiling Dependent Modules
+
+*Note:  AVA currently only transpiles the tests that you ask it to run.  In other words, it won't transitively transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES2015 and/or use the ES2015 module syntax).  While there are valid reasons for taking this approach (no impact/modification to the code under test), it may not be what you expect!*
 
 *As a simple workaround, you can use [Babel's require hook](https://babeljs.io/docs/usage/require/) in order to do on-the-fly transpiling of modules that are subsequently required.  Because AVA supports ES6 module syntax, you can use it to import the require hook itself:*
 
 ```js
 import 'babel-core/register';
 import test from 'ava';
-import foo from './foo'; // <-- foo can be written in ES6!
+import foo from './foo'; // <-- foo can be written in ES2015!
 
 test('foo bar', t => {
   t.same('baz', foo('bar');

--- a/readme.md
+++ b/readme.md
@@ -311,6 +311,23 @@ You can also use your own local Babel version:
 }
 ```
 
+*Note:  AVA currently only transpiled the tests that you ask it to run.  In other words, it won't transitively transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES6 and/or use the ES6 module syntax).  While there are valid reasons for taking this approach (no impact/modification to the code-under-test), it may not be what you expect!*
+
+*As a simple workaround, you can use [Babel's require hook](https://babeljs.io/docs/usage/require/) in order to do on-the-fly transpiling of modules that are subsequently required.  Because AVA supports ES6 module syntax, you can use it to import the require hook itself:*
+
+```js
+import 'babel-core/register';
+import test from 'ava';
+import foo from './foo'; // <-- foo can be written in ES6!
+
+test('foo bar', t => {
+  t.same('baz', foo('bar');
+  t.end();
+});
+```
+
+*[#111](https://github.com/sindresorhus/ava/issues/111) is tracking this item as a potential enhancement*
+
 ### Promise support
 
 If you return a promise in the test you don't need to explicitly end the test as it will end when the promise resolves.

--- a/readme.md
+++ b/readme.md
@@ -311,7 +311,7 @@ You can also use your own local Babel version:
 }
 ```
 
-*Note:  AVA currently only transpiled the tests that you ask it to run.  In other words, it won't transitively transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES6 and/or use the ES6 module syntax).  While there are valid reasons for taking this approach (no impact/modification to the code-under-test), it may not be what you expect!*
+*Note:  AVA currently only transpiles the tests that you ask it to run.  In other words, it won't transitively transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES6 and/or use the ES6 module syntax).  While there are valid reasons for taking this approach (no impact/modification to the code under test), it may not be what you expect!*
 
 *As a simple workaround, you can use [Babel's require hook](https://babeljs.io/docs/usage/require/) in order to do on-the-fly transpiling of modules that are subsequently required.  Because AVA supports ES6 module syntax, you can use it to import the require hook itself:*
 

--- a/readme.md
+++ b/readme.md
@@ -313,9 +313,9 @@ You can also use your own local Babel version:
 
 #### Transpiling Dependent Modules
 
-*Note:  AVA currently only transpiles the tests that you ask it to run.  In other words, it won't transitively transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES2015 and/or use the ES2015 module syntax).  While there are valid reasons for taking this approach (no impact/modification to the code under test), it may not be what you expect!*
+AVA currently only transpiles the tests that you ask it to run.  *It will not transpile modules that you ```import``` from outside of the test (that also may happen to be written in ES2015 and/or use the ES2015 module syntax).*  While there are valid reasons for taking this approach, it may not be what you expect!
 
-*As a simple workaround, you can use [Babel's require hook](https://babeljs.io/docs/usage/require/) in order to do on-the-fly transpiling of modules that are subsequently required.  Because AVA supports ES6 module syntax, you can use it to import the require hook itself:*
+As a simple workaround, you can use [Babel's require hook](https://babeljs.io/docs/usage/require/) in order to do on-the-fly transpiling of modules that are subsequently required.  Because AVA supports ES6 module syntax, you can use it to import the require hook itself:
 
 ```js
 import 'babel-core/register';
@@ -328,7 +328,7 @@ test('foo bar', t => {
 });
 ```
 
-*[#111](https://github.com/sindresorhus/ava/issues/111) is tracking this item as a potential enhancement*
+[#111](https://github.com/sindresorhus/ava/issues/111) is tracking this item as a potential enhancement.
 
 ### Promise support
 


### PR DESCRIPTION
Adverstise workaround for transpiling ES6 module imports in tests