### PR TITLE
context should not exist on before/after tests.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -26,7 +26,6 @@ function Test(title, fn) {
 	this.assertCount = 0;
 	this.planCount = null;
 	this.duration = null;
-	this.context = {};
 
 	// test type, can be: test, hook, eachHook
 	this.type = 'test';

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -273,13 +273,13 @@ test('shared context', function (t) {
 	var runner = new Runner();
 
 	runner.addBeforeHook(function (a) {
-		a.is(a.context.arr, undefined);
-		a.context.arr = [];
+		a.is(a.context, undefined);
+		a.context = {arr: []};
 		a.end();
 	});
 
 	runner.addAfterHook(function (a) {
-		a.is(a.context.arr, undefined);
+		a.is(a.context, undefined);
 		a.end();
 	});
 


### PR DESCRIPTION
IMO, since context is not shared in `before` and `after` hooks.
It should be an error to access it in either scenario.

(cherry picked from commit f298d72 on #243)
