### PR TITLE
Breaking: `t.end` requires `test.async`, and `t.plan` will not auto end tests. Fixes #244.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -33,7 +33,8 @@ function Runner(opts) {
 		type: 'test',
 		serial: false,
 		exclusive: false,
-		skipped: false
+		skipped: false,
+		async: false
 	}, this._addFn.bind(this));
 }
 
@@ -47,7 +48,8 @@ var chainableFunctions = {
 	skip: {skipped: true},
 	only: {exclusive: true},
 	beforeEach: {type: 'beforeEach'},
-	afterEach: {type: 'afterEach'}
+	afterEach: {type: 'afterEach'},
+	async: {async: true}
 };
 
 function makeChain(defaults, parentAdd) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -6,6 +6,7 @@ var fnName = require('fn-name');
 var co = require('co-with-promise');
 var observableToPromise = require('observable-to-promise');
 var isPromise = require('is-promise');
+var isObservable = require('is-observable');
 var assert = require('./assert');
 var globals = require('./globals');
 
@@ -30,7 +31,6 @@ function Test(title, fn) {
 
 	// TODO(jamestalmage): make this an optional constructor arg instead of having Runner set it after the fact.
 	// metadata should just always exist, otherwise it requires a bunch of ugly checks all over the place.
-	// I will fix this correctly in the upstream PR.
 	this.metadata = {};
 
 	// store the time point before test execution
@@ -51,12 +51,6 @@ module.exports = Test;
 
 Test.prototype._assert = function () {
 	this.assertCount++;
-
-	// TODO(jamestalmage): no only auto-ends in "declared" async mode `test.async(...)`. Should we drop auto-end behavior all together?
-	// https://github.com/sindresorhus/ava/issues/244#issuecomment-158705839
-	if (this.metadata.async && this.assertCount === this.planCount) {
-		globals.setImmediate(this.exit.bind(this));
-	}
 };
 
 // patch assert methods to increase assert count and store errors
@@ -139,24 +133,33 @@ Test.prototype.run = function () {
 		this.exit();
 	}
 
-	ret = observableToPromise(ret);
+	var asyncType = 'promises';
+
+	if (isObservable(ret)) {
+		asyncType = 'observables';
+		ret = observableToPromise(ret);
+	}
 
 	if (isPromise(ret)) {
-		if (!this.metadata.async) {
-			ret = ret.then(function () {
-				self.exit();
-			});
+		if (this.metadata.async) {
+			self._setAssertError(new Error('Do not return ' + asyncType + ' from tests declared via `test.async(...)`, if you want to return a promise simply declare the test via `test(...)`'));
+			this.exit();
+			return this.promise.promise;
 		}
 
-		ret.catch(function (err) {
-			self._setAssertError(new assert.AssertionError({
-				actual: err,
-				message: 'Promise rejected → ' + err,
-				operator: 'promise'
-			}));
+		ret
+			.then(function () {
+				self.exit();
+			})
+			.catch(function (err) {
+				self._setAssertError(new assert.AssertionError({
+					actual: err,
+					message: 'Promise rejected → ' + err,
+					operator: 'promise'
+				}));
 
-			self.exit();
-		});
+				self.exit();
+			});
 	} else if (!this.metadata.async) {
 		this.exit();
 	}

--- a/lib/test.js
+++ b/lib/test.js
@@ -28,6 +28,11 @@ function Test(title, fn) {
 	this.duration = null;
 	this.assertError = undefined;
 
+	// TODO(jamestalmage): make this an optional constructor arg instead of having Runner set it after the fact.
+	// metadata should just always exist, otherwise it requires a bunch of ugly checks all over the place.
+	// I will fix this correctly in the upstream PR.
+	this.metadata = {};
+
 	// store the time point before test execution
 	// to calculate the total time spent in test
 	this._timeStart = null;
@@ -47,7 +52,9 @@ module.exports = Test;
 Test.prototype._assert = function () {
 	this.assertCount++;
 
-	if (this.assertCount === this.planCount) {
+	// TODO(jamestalmage): no only auto-ends in "declared" async mode `test.async(...)`. Should we drop auto-end behavior all together?
+	// https://github.com/sindresorhus/ava/issues/244#issuecomment-158705839
+	if (this.metadata.async && this.assertCount === this.planCount) {
 		globals.setImmediate(this.exit.bind(this));
 	}
 };
@@ -135,27 +142,38 @@ Test.prototype.run = function () {
 	ret = observableToPromise(ret);
 
 	if (isPromise(ret)) {
-		ret
-			.then(function () {
-				if (!self.planCount || self.planCount === self.assertCount) {
-					self.exit();
-				}
-			})
-			.catch(function (err) {
-				self._setAssertError(new assert.AssertionError({
-					actual: err,
-					message: 'Promise rejected → ' + err,
-					operator: 'promise'
-				}));
-
+		if (!this.metadata.async) {
+			ret = ret.then(function () {
 				self.exit();
 			});
+		}
+
+		ret.catch(function (err) {
+			self._setAssertError(new assert.AssertionError({
+				actual: err,
+				message: 'Promise rejected → ' + err,
+				operator: 'promise'
+			}));
+
+			self.exit();
+		});
+	} else if (!this.metadata.async) {
+		this.exit();
 	}
 
 	return this.promise.promise;
 };
 
-Test.prototype.end = function (err) {
+Object.defineProperty(Test.prototype, 'end', {
+	get: function () {
+		if (this.metadata.async) {
+			return this._end;
+		}
+		throw new Error('t.end is not supported in this context. To use t.end as a callback, you must explicitly declare the test asynchronous via `test.async(testName, fn)` ');
+	}
+});
+
+Test.prototype._end = function (err) {
 	if (err) {
 		this._setAssertError(new assert.AssertionError({
 			actual: err,

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "has-flag": "^1.0.0",
     "has-generator": "^1.0.0",
     "is-generator-fn": "^1.0.0",
+    "is-observable": "^0.1.0",
     "is-promise": "^2.1.0",
     "loud-rejection": "^1.2.0",
     "max-timeout": "^1.0.0",

--- a/test/fixture/circular-reference-on-assertion.js
+++ b/test/fixture/circular-reference-on-assertion.js
@@ -4,5 +4,4 @@ test(t => {
 	var circular = ['a', 'b'];
 	circular.push(circular);
 	t.same([circular, 'c'], [circular, 'd']);
-	t.end();
 });

--- a/test/fixture/es2015.js
+++ b/test/fixture/es2015.js
@@ -2,5 +2,4 @@ import test from '../../';
 
 test(t => {
 	t.pass();
-	t.end();
 });

--- a/test/fixture/fail-fast.js
+++ b/test/fixture/fail-fast.js
@@ -2,10 +2,8 @@ import test from '../../';
 
 test(t => {
 	t.fail();
-	t.end();
 });
 
 test(t => {
 	t.pass();
-	t.end();
 });

--- a/test/fixture/hooks-failing.js
+++ b/test/fixture/hooks-failing.js
@@ -4,10 +4,8 @@ test.beforeEach(fail);
 test(pass);
 
 function pass(t) {
-	t.end();
 }
 
 function fail(t) {
 	t.fail();
-	t.end();
 }

--- a/test/fixture/hooks-passing.js
+++ b/test/fixture/hooks-passing.js
@@ -7,5 +7,4 @@ test.afterEach(pass);
 test(pass);
 
 function pass(t) {
-	t.end();
 }

--- a/test/fixture/long-running.js
+++ b/test/fixture/long-running.js
@@ -20,6 +20,7 @@ test.async('long running', function (t) {
 
 	setTimeout(function () {
 		t.ok(true);
+		t.end();
 	});
 
 	setTimeout(function () {

--- a/test/fixture/long-running.js
+++ b/test/fixture/long-running.js
@@ -2,7 +2,7 @@
 const test = require('../../');
 var onExit = require('signal-exit');
 
-test('long running', function (t) {
+test.async('long running', function (t) {
 	t.plan(1);
 
 	onExit(function () {

--- a/test/fixture/loud-rejection.js
+++ b/test/fixture/loud-rejection.js
@@ -1,6 +1,6 @@
 const test = require('../../');
 
-test('creates an unhandled rejection', t => {
+test.async('creates an unhandled rejection', t => {
 	Promise.reject(new Error(`You can't handle this!`));
 
 	setTimeout(function () {

--- a/test/fixture/one-pass-one-fail.js
+++ b/test/fixture/one-pass-one-fail.js
@@ -2,10 +2,8 @@ const test = require('../../');
 
 test('this is a passing test', t => {
 	t.ok(true);
-	t.end();
 });
 
 test('this is a failing test', t => {
 	t.ok(false);
-	t.end();
 });

--- a/test/fixture/power-assert.js
+++ b/test/fixture/power-assert.js
@@ -4,5 +4,4 @@ test(t => {
 	const a = 'foo';
 
 	t.ok(a === 'bar');
-	t.end();
 });

--- a/test/fixture/process-cwd.js
+++ b/test/fixture/process-cwd.js
@@ -3,5 +3,4 @@ const test = require('../../');
 
 test(t => {
 	t.is(process.cwd(), __dirname);
-	t.end();
 });

--- a/test/fixture/serial.js
+++ b/test/fixture/serial.js
@@ -6,14 +6,14 @@ function randomDelay() {
 
 const tests = [];
 
-test('first', t => {
+test.async('first', t => {
 	setTimeout(() => {
 		tests.push('first');
 		t.end();
 	}, randomDelay());
 });
 
-test('second', t => {
+test.async('second', t => {
 	setTimeout(() => {
 		tests.push('second');
 		t.end();
@@ -22,5 +22,4 @@ test('second', t => {
 
 test(t => {
 	t.same(tests, ['first', 'second']);
-	t.end();
 });

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -10,14 +10,12 @@ test('before', function (t) {
 	var runner = new Runner();
 	var arr = [];
 
-	runner.before(function (a) {
+	runner.before(function () {
 		arr.push('a');
-		a.end();
 	});
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr.push('b');
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -26,22 +24,22 @@ test('before', function (t) {
 });
 
 test('after', function (t) {
-	t.plan(1);
+	t.plan(3);
 
 	var runner = new Runner();
 	var arr = [];
 
-	runner.after(function (a) {
+	runner.after(function () {
 		arr.push('b');
-		a.end();
 	});
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr.push('a');
-		a.end();
 	});
 
 	runner.run().then(function () {
+		t.is(runner.stats.passCount, 1);
+		t.is(runner.stats.failCount, 0);
 		t.same(arr, ['a', 'b']);
 		t.end();
 	});
@@ -53,9 +51,8 @@ test('stop if before hooks failed', function (t) {
 	var runner = new Runner();
 	var arr = [];
 
-	runner.before(function (a) {
+	runner.before(function () {
 		arr.push('a');
-		a.end();
 	});
 
 	runner.before(function () {
@@ -81,24 +78,20 @@ test('before each with concurrent tests', function (t) {
 	var i = 0;
 	var k = 0;
 
-	runner.beforeEach(function (a) {
+	runner.beforeEach(function () {
 		arr[i++].push('a');
-		a.end();
 	});
 
-	runner.beforeEach(function (a) {
+	runner.beforeEach(function () {
 		arr[k++].push('b');
-		a.end();
 	});
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr[0].push('c');
-		a.end();
 	});
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr[1].push('d');
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -113,24 +106,20 @@ test('before each with serial tests', function (t) {
 	var runner = new Runner();
 	var arr = [];
 
-	runner.beforeEach(function (a) {
+	runner.beforeEach(function () {
 		arr.push('a');
-		a.end();
 	});
 
-	runner.beforeEach(function (a) {
+	runner.beforeEach(function () {
 		arr.push('b');
-		a.end();
 	});
 
-	runner.serial(function (a) {
+	runner.serial(function () {
 		arr.push('c');
-		a.end();
 	});
 
-	runner.serial(function (a) {
+	runner.serial(function () {
 		arr.push('d');
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -148,13 +137,11 @@ test('fail if beforeEach hook fails', function (t) {
 	runner.beforeEach(function (a) {
 		arr.push('a');
 		a.fail();
-		a.end();
 	});
 
 	runner.test(function (a) {
 		arr.push('b');
 		a.pass();
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -172,24 +159,20 @@ test('after each with concurrent tests', function (t) {
 	var i = 0;
 	var k = 0;
 
-	runner.afterEach(function (a) {
+	runner.afterEach(function () {
 		arr[i++].push('a');
-		a.end();
 	});
 
-	runner.afterEach(function (a) {
+	runner.afterEach(function () {
 		arr[k++].push('b');
-		a.end();
 	});
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr[0].push('c');
-		a.end();
 	});
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr[1].push('d');
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -204,24 +187,20 @@ test('after each with serial tests', function (t) {
 	var runner = new Runner();
 	var arr = [];
 
-	runner.afterEach(function (a) {
+	runner.afterEach(function () {
 		arr.push('a');
-		a.end();
 	});
 
-	runner.afterEach(function (a) {
+	runner.afterEach(function () {
 		arr.push('b');
-		a.end();
 	});
 
-	runner.serial(function (a) {
+	runner.serial(function () {
 		arr.push('c');
-		a.end();
 	});
 
-	runner.serial(function (a) {
+	runner.serial(function () {
 		arr.push('d');
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -236,29 +215,24 @@ test('ensure hooks run only around tests', function (t) {
 	var runner = new Runner();
 	var arr = [];
 
-	runner.beforeEach(function (a) {
+	runner.beforeEach(function () {
 		arr.push('beforeEach');
-		a.end();
 	});
 
-	runner.before(function (a) {
+	runner.before(function () {
 		arr.push('before');
-		a.end();
 	});
 
-	runner.afterEach(function (a) {
+	runner.afterEach(function () {
 		arr.push('afterEach');
-		a.end();
 	});
 
-	runner.after(function (a) {
+	runner.after(function () {
 		arr.push('after');
-		a.end();
 	});
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr.push('test');
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -275,29 +249,24 @@ test('shared context', function (t) {
 	runner.before(function (a) {
 		a.is(a.context, undefined);
 		a.context = {arr: []};
-		a.end();
 	});
 
 	runner.after(function (a) {
 		a.is(a.context, undefined);
-		a.end();
 	});
 
 	runner.beforeEach(function (a) {
 		a.context.arr = ['a'];
-		a.end();
 	});
 
 	runner.test(function (a) {
 		a.context.arr.push('b');
 		a.same(a.context.arr, ['a', 'b']);
-		a.end();
 	});
 
 	runner.afterEach(function (a) {
 		a.context.arr.push('c');
 		a.same(a.context.arr, ['a', 'b', 'c']);
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -313,12 +282,10 @@ test('shared context of any type', function (t) {
 
 	runner.beforeEach(function (a) {
 		a.context = 'foo';
-		a.end();
 	});
 
 	runner.test(function (a) {
 		a.is(a.context, 'foo');
-		a.end();
 	});
 
 	runner.run().then(function () {

--- a/test/observable.js
+++ b/test/observable.js
@@ -1,10 +1,22 @@
 'use strict';
 var test = require('tap').test;
-var ava = require('../lib/test');
+var _ava = require('../lib/test');
 var Observable = require('./fixture/observable');
 
+function ava(fn) {
+	var a = _ava(fn);
+	a.metadata = {async: false};
+	return a;
+}
+
+ava.async = function (fn) {
+	var a = _ava(fn);
+	a.metadata = {async: true};
+	return a;
+};
+
 test('plan assertions', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(2);
 
 		var observable = Observable.of();
@@ -23,7 +35,7 @@ test('plan assertions', function (t) {
 });
 
 test('handle throws with thrown observable', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
@@ -38,7 +50,7 @@ test('handle throws with thrown observable', function (t) {
 });
 
 test('handle throws with long running thrown observable', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
@@ -55,7 +67,7 @@ test('handle throws with long running thrown observable', function (t) {
 });
 
 test('handle throws with completed observable', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = Observable.of();
@@ -68,7 +80,7 @@ test('handle throws with completed observable', function (t) {
 });
 
 test('handle throws with regex', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
@@ -83,7 +95,7 @@ test('handle throws with regex', function (t) {
 });
 
 test('handle throws with string', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
@@ -98,7 +110,7 @@ test('handle throws with string', function (t) {
 });
 
 test('handle throws with false-positive observable', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
@@ -115,7 +127,7 @@ test('handle throws with false-positive observable', function (t) {
 });
 
 test('handle doesNotThrow with completed observable', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = Observable.of();
@@ -127,7 +139,7 @@ test('handle doesNotThrow with completed observable', function (t) {
 });
 
 test('handle doesNotThrow with thrown observable', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {

--- a/test/observable.js
+++ b/test/observable.js
@@ -15,7 +15,7 @@ ava.async = function (fn) {
 	return a;
 };
 
-test('plan assertions', function (t) {
+test('returning an observable from a legacy async fn is an error', function (t) {
 	ava.async(function (a) {
 		a.plan(2);
 
@@ -24,25 +24,25 @@ test('plan assertions', function (t) {
 		setTimeout(function () {
 			a.pass();
 			a.pass();
+			a.end();
 		}, 200);
 
 		return observable;
-	}).run().then(function (a) {
-		t.is(a.planCount, 2);
-		t.is(a.assertCount, 2);
+	}).run().catch(function (err) {
+		t.match(err.message, /Do not return observables/);
 		t.end();
 	});
 });
 
 test('handle throws with thrown observable', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
 			observer.error(new Error());
 		});
 
-		a.throws(observable);
+		return a.throws(observable);
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -50,7 +50,7 @@ test('handle throws with thrown observable', function (t) {
 });
 
 test('handle throws with long running thrown observable', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
@@ -59,7 +59,7 @@ test('handle throws with long running thrown observable', function (t) {
 			}, 2000);
 		});
 
-		a.throws(observable, /abc/);
+		return a.throws(observable, /abc/);
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -67,11 +67,11 @@ test('handle throws with long running thrown observable', function (t) {
 });
 
 test('handle throws with completed observable', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = Observable.of();
-		a.throws(observable);
+		return a.throws(observable);
 	}).run().catch(function (err) {
 		t.ok(err);
 		t.is(err.name, 'AssertionError');
@@ -80,14 +80,14 @@ test('handle throws with completed observable', function (t) {
 });
 
 test('handle throws with regex', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
 			observer.error(new Error('abc'));
 		});
 
-		a.throws(observable, /abc/);
+		return a.throws(observable, /abc/);
 	}).run().then(function (a) {
 		t.notOk(a.assertionError);
 		t.end();
@@ -95,14 +95,14 @@ test('handle throws with regex', function (t) {
 });
 
 test('handle throws with string', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
 			observer.error(new Error('abc'));
 		});
 
-		a.throws(observable, 'abc');
+		return a.throws(observable, 'abc');
 	}).run().then(function (a) {
 		t.notOk(a.assertionError);
 		t.end();
@@ -110,7 +110,7 @@ test('handle throws with string', function (t) {
 });
 
 test('handle throws with false-positive observable', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
@@ -118,7 +118,7 @@ test('handle throws with false-positive observable', function (t) {
 			observer.complete();
 		});
 
-		a.throws(observable);
+		return a.throws(observable);
 	}).run().catch(function (err) {
 		t.ok(err);
 		t.is(err.name, 'AssertionError');
@@ -127,11 +127,11 @@ test('handle throws with false-positive observable', function (t) {
 });
 
 test('handle doesNotThrow with completed observable', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = Observable.of();
-		a.doesNotThrow(observable);
+		return a.doesNotThrow(observable);
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -139,14 +139,14 @@ test('handle doesNotThrow with completed observable', function (t) {
 });
 
 test('handle doesNotThrow with thrown observable', function (t) {
-	ava.async(function (a) {
+	ava(function (a) {
 		a.plan(1);
 
 		var observable = new Observable(function (observer) {
 			observer.error(new Error());
 		});
 
-		a.doesNotThrow(observable);
+		return a.doesNotThrow(observable);
 	}).run().catch(function (err) {
 		t.ok(err);
 		t.is(err.name, 'AssertionError');

--- a/test/runner.js
+++ b/test/runner.js
@@ -136,7 +136,7 @@ test('runner emits a "test" event', function (t) {
 	var runner = new Runner();
 
 	runner.test(function foo(a) {
-		a.end();
+		a.pass();
 	});
 
 	runner.on('test', function (props) {
@@ -179,9 +179,8 @@ test('anything can be skipped', function (t) {
 	var arr = [];
 
 	function pusher(title) {
-		return function (a) {
+		return function () {
 			arr.push(title);
-			a.end();
 		};
 	}
 
@@ -230,7 +229,7 @@ test('test types and titles', function (t) {
 	runner.test('test', pass);
 
 	function pass(a) {
-		a.end();
+		a.pass();
 	}
 
 	var tests = [
@@ -257,14 +256,12 @@ test('skip test', function (t) {
 	var runner = new Runner();
 	var arr = [];
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr.push('a');
-		a.end();
 	});
 
-	runner.skip(function (a) {
+	runner.skip(function () {
 		arr.push('b');
-		a.end();
 	});
 
 	runner.run().then(function () {
@@ -281,14 +278,12 @@ test('only test', function (t) {
 	var runner = new Runner();
 	var arr = [];
 
-	runner.test(function (a) {
+	runner.test(function () {
 		arr.push('a');
-		a.end();
 	});
 
-	runner.only(function (a) {
+	runner.only(function () {
 		arr.push('b');
-		a.end();
 	});
 
 	runner.run().then(function () {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,18 @@
 'use strict';
 var test = require('tap').test;
-var ava = require('../lib/test');
+var _ava = require('../lib/test');
+
+function ava() {
+	var t = _ava.apply(null, arguments);
+	t.metadata = {async: false};
+	return t;
+}
+
+ava.async = function () {
+	var t = _ava.apply(null, arguments);
+	t.metadata = {async: true};
+	return t;
+};
 
 test('run test', function (t) {
 	ava('foo', function (a) {
@@ -14,7 +26,7 @@ test('run test', function (t) {
 
 test('title is optional', function (t) {
 	ava(function (a) {
-		a.end();
+		a.pass();
 	}).run().then(function (a) {
 		t.is(a.title, '[anonymous]');
 		t.end();
@@ -35,7 +47,7 @@ test('callback is required', function (t) {
 
 test('infer name from function', function (t) {
 	ava(function foo(a) {
-		a.end();
+		a.pass();
 	}).run().then(function (a) {
 		t.is(a.title, 'foo');
 		t.end();
@@ -47,7 +59,6 @@ test('multiple asserts', function (t) {
 		a.pass();
 		a.pass();
 		a.pass();
-		a.end();
 	}).run().then(function (a) {
 		t.is(a.assertCount, 3);
 		t.end();
@@ -90,7 +101,7 @@ test('handle non-assertion errors', function (t) {
 });
 
 test('end can be used as callback without maintaining thisArg', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		setTimeout(a.end);
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
@@ -121,7 +132,6 @@ test('handle non-assertion errors even when planned', function (t) {
 test('handle testing of arrays', function (t) {
 	ava(function (a) {
 		a.same(['foo', 'bar'], ['foo', 'bar']);
-		a.end();
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -131,7 +141,6 @@ test('handle testing of arrays', function (t) {
 test('handle falsy testing of arrays', function (t) {
 	ava(function (a) {
 		a.notSame(['foo', 'bar'], ['foo', 'bar', 'cat']);
-		a.end();
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -141,7 +150,6 @@ test('handle falsy testing of arrays', function (t) {
 test('handle testing of objects', function (t) {
 	ava(function (a) {
 		a.same({foo: 'foo', bar: 'bar'}, {foo: 'foo', bar: 'bar'});
-		a.end();
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -151,7 +159,6 @@ test('handle testing of objects', function (t) {
 test('handle falsy testing of objects', function (t) {
 	ava(function (a) {
 		a.notSame({foo: 'foo', bar: 'bar'}, {foo: 'foo', bar: 'bar', cat: 'cake'});
-		a.end();
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -163,8 +170,6 @@ test('handle throws with error', function (t) {
 		a.throws(function () {
 			throw new Error('foo');
 		});
-
-		a.end();
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -176,8 +181,6 @@ test('handle throws without error', function (t) {
 		a.throws(function () {
 			return;
 		});
-
-		a.end();
 	}).run().catch(function (err) {
 		t.ok(err);
 		t.end();
@@ -189,8 +192,6 @@ test('handle doesNotThrow with error', function (t) {
 		a.doesNotThrow(function () {
 			throw new Error('foo');
 		});
-
-		a.end();
 	}).run().catch(function (err) {
 		t.ok(err);
 		t.is(err.name, 'AssertionError');
@@ -203,8 +204,6 @@ test('handle doesNotThrow without error', function (t) {
 		a.doesNotThrow(function () {
 			return;
 		});
-
-		a.end();
 	}).run().then(function (a) {
 		t.notOk(a.assertError);
 		t.end();
@@ -227,7 +226,7 @@ test('run functions after last planned assertion', function (t) {
 test('run async functions after last planned assertion', function (t) {
 	var i = 0;
 
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		function foo(cb) {
@@ -245,7 +244,7 @@ test('run async functions after last planned assertion', function (t) {
 });
 
 test('planned async assertion', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		setTimeout(function () {
@@ -258,7 +257,7 @@ test('planned async assertion', function (t) {
 });
 
 test('async assertion with `.end()`', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		setTimeout(function () {
 			a.pass();
 			a.end();
@@ -282,7 +281,7 @@ test('more assertions than planned should emit an assertion error', function (t)
 });
 
 test('record test duration', function (t) {
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		setTimeout(function () {
@@ -297,7 +296,7 @@ test('record test duration', function (t) {
 test('wait for test to end', function (t) {
 	var avaTest;
 
-	ava(function (a) {
+	ava.async(function (a) {
 		a.plan(1);
 
 		avaTest = a;

--- a/test/test.js
+++ b/test/test.js
@@ -228,15 +228,9 @@ test('run async functions after last planned assertion', function (t) {
 
 	ava.async(function (a) {
 		a.plan(1);
-
-		function foo(cb) {
-			a.pass();
-			cb();
-		}
-
-		foo(function () {
-			i++;
-		});
+		a.pass();
+		a.end();
+		i++;
 	}).run().then(function () {
 		t.is(i, 1);
 		t.end();
@@ -249,6 +243,7 @@ test('planned async assertion', function (t) {
 
 		setTimeout(function () {
 			a.pass();
+			a.end();
 		}, 100);
 	}).run().then(function (a) {
 		t.ifError(a.assertError);
@@ -286,6 +281,7 @@ test('record test duration', function (t) {
 
 		setTimeout(function () {
 			a.true(true);
+			a.end();
 		}, 1234);
 	}).run().then(function (a) {
 		t.true(a.duration >= 1234);
@@ -309,6 +305,7 @@ test('wait for test to end', function (t) {
 
 	setTimeout(function () {
 		avaTest.pass();
+		avaTest.end();
 	}, 1234);
 });
 


### PR DESCRIPTION
See #244

