### PR TITLE
Add source map support. Fixes: #223, #250

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -1,4 +1,18 @@
 'use strict';
+var sourceMapCache = Object.create(null);
+
+require('source-map-support').install({
+	retrieveSourceMap: function (source) {
+		if (sourceMapCache[source]) {
+			return {
+				url: source,
+				map: sourceMapCache[source]
+			};
+		}
+		return null;
+	}
+});
+
 var createEspowerPlugin = require('babel-plugin-espower/create');
 var requireFromString = require('require-from-string');
 var loudRejection = require('loud-rejection/api')(process);
@@ -28,7 +42,8 @@ var powerAssert = createEspowerPlugin(babel, {
 var options = {
 	blacklist: hasGenerator ? ['regenerator'] : [],
 	optional: hasGenerator ? ['asyncToGenerator', 'runtime'] : ['runtime'],
-	plugins: [powerAssert]
+	plugins: [powerAssert],
+	sourceMaps: true
 };
 
 // check if test files required ava and show error, when they didn't
@@ -40,6 +55,7 @@ process.on('uncaughtException', function (exception) {
 
 // include test file
 var transpiled = babel.transformFileSync(testPath, options);
+sourceMapCache[testPath] = JSON.stringify(transpiled.map);
 requireFromString(transpiled.code, testPath, {
 	appendPaths: module.paths
 });

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "require-from-string": "^1.1.0",
     "resolve-from": "^1.0.0",
     "set-immediate-shim": "^1.0.1",
+    "source-map-support": "^0.3.3",
     "squeak": "^1.2.0",
     "update-notifier": "^0.5.0"
   },

--- a/test/cli.js
+++ b/test/cli.js
@@ -166,6 +166,8 @@ test('uncaught exception will be reported to console', function (t) {
 	execCli('fixture/uncaught-exception.js', function (err, stdout, stderr) {
 		t.ok(err);
 		t.true(/Can't catch me!/.test(stderr));
+		t.match(stderr, /^.*?at.*?bar\b.*uncaught-exception.js:12.*$/m);
+		t.match(stderr, /^.*?at.*?foo\b.*uncaught-exception.js:8.*$/m);
 		// TODO(jamestalmage): This should get printed, but we reject the promise (ending all tests) instead of just ending that one test and reporting.
 		// t.ok(/1 uncaught exception[^s]/.test(stdout));
 		t.end();

--- a/test/fixture/uncaught-exception.js
+++ b/test/fixture/uncaught-exception.js
@@ -1,7 +1,13 @@
 const test = require('../../');
 
 test('throw an uncaught exception', t => {
-	setImmediate(() => {
-		throw new Error(`Can't catch me!`)
-	});
+	setImmediate(foo);
 });
+
+function foo() {
+	bar();
+}
+
+function bar() {
+	throw new Error(`Can't catch me!`)
+}


### PR DESCRIPTION
Fixes #223, #250 

This adds basic source map support. Since transpilation of dependencies
is not merged yet, the `sourceMapCache` object and lookup is a little
premature (since we will only ever have one file that we can apply
apply source maps to).