### PR TITLE
print the first assertion failure of each test, instead of the last. Fixes #121, #220

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -83,12 +83,15 @@ Object.keys(assert).forEach(function (el) {
 });
 
 Test.prototype._setAssertError = function (err) {
-	if (this.assertError === undefined) {
-		if (err === undefined) {
-			err = 'undefined';
-		}
-		this.assertError = err;
+	if (this.assertError !== undefined) {
+		return;
 	}
+
+	if (err === undefined) {
+		err = 'undefined';
+	}
+
+	this.assertError = err;
 };
 
 // Workaround for power-assert

--- a/lib/test.js
+++ b/lib/test.js
@@ -26,6 +26,7 @@ function Test(title, fn) {
 	this.assertCount = 0;
 	this.planCount = null;
 	this.duration = null;
+	this.assertError = undefined;
 
 	// test type, can be: test, hook, eachHook
 	this.type = 'test';
@@ -67,19 +68,28 @@ Object.keys(assert).forEach(function (el) {
 			if (isPromise(fn)) {
 				return Promise.resolve(fn)
 					.catch(function (err) {
-						self.assertError = err;
+						self._setAssertError(err);
 					})
 					.finally(function () {
 						self._assert();
 					});
 			}
 		} catch (err) {
-			this.assertError = err;
+			this._setAssertError(err);
 		}
 
 		this._assert();
 	};
 });
+
+Test.prototype._setAssertError = function (err) {
+	if (this.assertError === undefined) {
+		if (err === undefined) {
+			err = 'undefined';
+		}
+		this.assertError = err;
+	}
+};
 
 // Workaround for power-assert
 // `t` must be capturable for decorated assert output
@@ -118,7 +128,7 @@ Test.prototype.run = function () {
 	try {
 		ret = this.fn(this);
 	} catch (err) {
-		this.assertError = err;
+		this._setAssertError(err);
 		this.exit();
 	}
 
@@ -132,11 +142,11 @@ Test.prototype.run = function () {
 				}
 			})
 			.catch(function (err) {
-				self.assertError = new assert.AssertionError({
+				self._setAssertError(new assert.AssertionError({
 					actual: err,
 					message: 'Promise rejected → ' + err,
 					operator: 'promise'
-				});
+				}));
 
 				self.exit();
 			});
@@ -147,11 +157,11 @@ Test.prototype.run = function () {
 
 Test.prototype.end = function (err) {
 	if (err) {
-		this.assertError = new assert.AssertionError({
+		this._setAssertError(new assert.AssertionError({
 			actual: err,
 			message: 'Callback called with an error → ' + err,
 			operator: 'callback'
-		});
+		}));
 
 		this.exit();
 		return;
@@ -174,13 +184,13 @@ Test.prototype.exit = function () {
 	// stop infinite timer
 	clearTimeout(this._timeout);
 
-	if (!this.assertError && this.planCount !== null && this.planCount !== this.assertCount) {
-		this.assertError = new assert.AssertionError({
+	if (this.assertError === undefined && this.planCount !== null && this.planCount !== this.assertCount) {
+		this._setAssertError(new assert.AssertionError({
 			actual: this.assertCount,
 			expected: this.planCount,
 			message: 'Assertion count does not match planned',
 			operator: 'plan'
-		});
+		}));
 
 		this.assertError.stack = this.planStack;
 	}
@@ -189,7 +199,7 @@ Test.prototype.exit = function () {
 		this.ended = true;
 
 		setImmediate(function () {
-			if (self.assertError) {
+			if (self.assertError !== undefined) {
 				self.promise.reject(self.assertError);
 				return;
 			}

--- a/readme.md
+++ b/readme.md
@@ -433,6 +433,8 @@ test(t => {
 });
 ```
 
+If multiple assertion failures are encountered within a single test, AVA will only display the *first* one.
+
 ### .pass([message])
 
 Passing assertion.

--- a/test/test.js
+++ b/test/test.js
@@ -313,7 +313,7 @@ test('wait for test to end', function (t) {
 	}, 1234);
 });
 
-test('promise is rejected with the first assertError', function (t) {
+test('fails with the first assertError', function (t) {
 	ava(function (a) {
 		a.plan(2);
 		a.is(1, 2);
@@ -325,7 +325,7 @@ test('promise is rejected with the first assertError', function (t) {
 	});
 });
 
-test('promise is rejected with thrown falsie value', function (t) {
+test('fails with thrown falsie value', function (t) {
 	ava(function () {
 		throw 0; // eslint-disable-line no-throw-literal
 	}).run().catch(function (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -325,7 +325,7 @@ test('fails with the first assertError', function (t) {
 	});
 });
 
-test('fails with thrown falsie value', function (t) {
+test('fails with thrown falsy value', function (t) {
 	ava(function () {
 		throw 0; // eslint-disable-line no-throw-literal
 	}).run().catch(function (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -312,3 +312,33 @@ test('wait for test to end', function (t) {
 		avaTest.pass();
 	}, 1234);
 });
+
+test('promise is rejected with the first assertError', function (t) {
+	ava(function (a) {
+		a.plan(2);
+		a.is(1, 2);
+		a.is(3, 4);
+	}).run().catch(function (err) {
+		t.is(err.actual, 1);
+		t.is(err.expected, 2);
+		t.end();
+	});
+});
+
+test('promise is rejected with thrown falsie value', function (t) {
+	ava(function () {
+		throw 0; // eslint-disable-line no-throw-literal
+	}).run().catch(function (err) {
+		t.equal(err, 0);
+		t.end();
+	});
+});
+
+test('throwing undefined will be converted to string "undefined"', function (t) {
+	ava(function () {
+		throw undefined; // eslint-disable-line no-throw-literal
+	}).run().catch(function (err) {
+		t.equal(err, 'undefined');
+		t.end();
+	});
+});


### PR DESCRIPTION
Fixes #121.
Fixes #220.