### PR TITLE
Ignore possible test files under node_modules folder. Fixes #226.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+!test/fixture/node_modules
 .nyc_output

--- a/cli.js
+++ b/cli.js
@@ -201,11 +201,17 @@ function init(files) {
 function handlePaths(files) {
 	if (files.length === 0) {
 		files = [
+			'!node_modules',
 			'test.js',
 			'test-*.js',
 			'test/*.js'
 		];
 	}
+
+	// ignore all possible test files in node_modules folder
+	files = files.filter(function (file) {
+		return (file.indexOf('node_modules') === -1);
+	});
 
 	// convert pinkie-promise to Bluebird promise
 	files = Promise.resolve(globby(files));

--- a/cli.js
+++ b/cli.js
@@ -201,12 +201,13 @@ function init(files) {
 function handlePaths(files) {
 	if (files.length === 0) {
 		files = [
-			'!node_modules',
 			'test.js',
 			'test-*.js',
 			'test/*.js'
 		];
 	}
+
+	files.push('!**/node_modules/**');
 
 	// convert pinkie-promise to Bluebird promise
 	files = Promise.resolve(globby(files));
@@ -221,7 +222,7 @@ function handlePaths(files) {
 		})
 		.then(flatten)
 		.filter(function (file) {
-			return file.indexOf('node_modules') === -1 && path.extname(file) === '.js' && path.basename(file)[0] !== '_';
+			return path.extname(file) === '.js' && path.basename(file)[0] !== '_';
 		});
 }
 

--- a/cli.js
+++ b/cli.js
@@ -208,11 +208,6 @@ function handlePaths(files) {
 		];
 	}
 
-	// ignore all possible test files in node_modules folder
-	files = files.filter(function (file) {
-		return (file.indexOf('node_modules') === -1);
-	});
-
 	// convert pinkie-promise to Bluebird promise
 	files = Promise.resolve(globby(files));
 
@@ -226,7 +221,7 @@ function handlePaths(files) {
 		})
 		.then(flatten)
 		.filter(function (file) {
-			return path.extname(file) === '.js' && path.basename(file)[0] !== '_';
+			return file.indexOf('node_modules') === -1 && path.extname(file) === '.js' && path.basename(file)[0] !== '_';
 		});
 }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -243,3 +243,11 @@ test('test file that immediately exits with 0 exit code ', function (t) {
 		t.end();
 	});
 });
+
+test('test file in node_modules is ignored', function (t) {
+	execCli('fixture/node_modules/test.js', function (err, stdout, stderr) {
+		t.ok(err);
+		t.true(/Couldn't find any files to test/.test(stderr));
+		t.end();
+	});
+});

--- a/test/fixture/node_modules/test.js
+++ b/test/fixture/node_modules/test.js
@@ -1,0 +1,6 @@
+import test from '../../';
+
+test(t => {
+	t.pass();
+	t.end();
+});


### PR DESCRIPTION
As noted in #226, this pull request does two things:

* Add `!node_modules` to the array [https://github.com/sindresorhus/ava/blob/master/cli.js#L203](here), so that it ignores the folder when ava is ran with no arguments.

* Filter out any matched file that has the string `node_modules` in it. This works in case the user does something like `ava **`, which is rare but can happen.

Perhaps there's a more efficient way to do this, but I have tested this in various cases and it works, though I haven't been able to write a proper test for it.

Thanks and let me know if there's anything I can improve on.