### PR TITLE
Fix coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .nyc_output
+coverage

--- a/maintaining.md
+++ b/maintaining.md
@@ -1,6 +1,13 @@
 # Maintaining
 
 
+## Testing
+
+ - `npm test`: Lint the code and run the entire test suite with coverage.
+ - `npm run test-win`: Run the tests on Windows.
+ - `npm run coverage`: Generate a coverage report for the last test run (opens a browser window).
+ - `tap test/fork.js -b`: Run a specific test file and bail on the first failure (useful when hunting bugs). 
+
 ## Release process
 
 - Bump dependencies.

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
   },
   "scripts": {
     "test": "xo && tap --coverage --reporter=spec --timeout=150 test/*.js",
-    "test-win": "tap --coverage --reporter=spec --timeout=150 test/*.js",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls"
+    "test-win": "tap --reporter=spec --timeout=150 test/*.js",
+    "coveralls": "tap --coverage-report=text-lcov | coveralls",
+    "coverage": "tap --coverage-report=lcov"
   },
   "files": [
     "index.js",
@@ -75,6 +76,14 @@
     "observable",
     "observables"
   ],
+  "config": {
+    "nyc": {
+      "exclude": [
+        "node_modules[/\\\\]",
+        "test[/\\\\]"
+      ]
+    }
+  },
   "dependencies": {
     "arr-flatten": "^1.0.1",
     "ava-init": "^0.1.0",
@@ -112,7 +121,6 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.4",
-    "nyc": "^3.2.2",
     "signal-exit": "^2.1.2",
     "tap": "^2.2.1",
     "xo": "*",


### PR DESCRIPTION
Due to NYC defaults, we were missing coverage on lib/test.js

I also added `npm run coverage` as a build target, which is for use
on developer machines. It launches a browser window with coverage
from the last run.

We no longer need NYC ~~or coveralls~~ as dev dependencies. `tap` handles
it all for us magically.

`maintaining.md` updated to reflect all these changes.

Also - I dropped coverage from the Windows tests. We don't need to make AppVeyor any slower.