### PR TITLE
Fix failing coveralls script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js:
   - 'stable'
   - '0.12'
   - '0.10'
-after_success: npm run coveralls
+after_success:
+  - '[ -z "$COVERALLS_REPO_TOKEN" ] && tap --coverage-report=text-lcov | ./node_modules/.bin/coveralls'

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "scripts": {
     "test": "xo && tap --coverage --reporter=spec --timeout=150 test/*.js",
     "test-win": "tap --reporter=spec --timeout=150 test/*.js",
-    "coveralls": "tap --coverage-report=text-lcov | coveralls",
     "coverage": "tap --coverage-report=lcov"
   },
   "files": [


### PR DESCRIPTION
For PR's `process.env.COVERALLS_REPO_TOKEN` does not exist, so `tap`
will **not** automatically send data to coveralls. Hence our existing script:
`npm run coveralls`. Unfortuneately that seems to create problems
when merged onto master. In that case `tap` **will**
automatically push our coverage data, and the follow up script seems to fail.

To fix all this, I check the environment variable in .travis.yaml, and
manually push the coverage data if the environment variable does not exist.

Example Failing Build: 
  https://travis-ci.org/sindresorhus/ava/jobs/92855751
