### PR TITLE
Pipe forked IO streams instead of forwarding `data` events.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -113,10 +113,7 @@ function run(file) {
 		.on('stats', stats)
 		.on('test', test)
 		.on('unhandledRejections', handleRejections)
-		.on('uncaughtException', handleExceptions)
-		.on('data', function (data) {
-			process.stdout.write(data);
-		});
+		.on('uncaughtException', handleExceptions);
 }
 
 function handleRejections(data) {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -14,8 +14,8 @@ module.exports = function (args) {
 	var file = args[0];
 
 	var options = {
-		silent: true,
-		cwd: path.dirname(file)
+		cwd: path.dirname(file),
+		stdio: ['ignore', process.stdout, process.stdout]
 	};
 
 	var ps = childProcess.fork(filepath, args, options);
@@ -74,15 +74,6 @@ module.exports = function (args) {
 	// uncaught exception in fork, need to exit
 	ps.on('uncaughtException', function () {
 		send(ps, 'teardown');
-	});
-
-	// emit data events on forked process' output
-	ps.stdout.on('data', function (data) {
-		ps.emit('data', data);
-	});
-
-	ps.stderr.on('data', function (data) {
-		ps.emit('data', data);
 	});
 
 	promise.on = function () {


### PR DESCRIPTION
This passes terminal width information to, and enables ansi-color
support in, the forked process. It makes the output of `time-require`
much prettier when used in a fork.