### PR TITLE
Integrate time-require into the CLI.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 'use strict';
+
+var debug = require('debug')('ava');
+
+if (debug.enabled) {
+	require('time-require');
+}
+
 var fs = require('fs');
 var path = require('path');
 var figures = require('figures');
@@ -107,6 +114,12 @@ function run(file) {
 
 	if (cli.flags.serial) {
 		args.push('--serial');
+	}
+
+	// Forward the `time-require` `--sorted` flag.
+	// Intended for internal optimization tests only.
+	if (cli.flags.sorted) {
+		args.push('--sorted');
 	}
 
 	return fork(args)

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -1,5 +1,11 @@
 'use strict';
 
+var debug = require('debug')('ava');
+
+if (debug.enabled) {
+	require('time-require');
+}
+
 // Bind globals first, before anything has a chance to interfere.
 var globals = require('./globals');
 

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "set-immediate-shim": "^1.0.1",
     "source-map-support": "^0.3.3",
     "squeak": "^1.2.0",
+    "time-require": "^0.1.2",
     "update-notifier": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I want to start focusing on getting our require times down,
both in the main thread and forked tests.

This adds `time-require` support directly to the CLI to assist in that.
This is especially important for forked test processes, where I currently
have to manually add a line of code each time I want to test an optimization.

I don't think this should be a publicly documented move. I think we want
the freedom to remove this once we are happy with performance.

I have placed comments above all `time-require` references, indicating
it is for internal use only. Users have been given fair warning against
relying on its inclusion long term.

Usage:

```sh
$ ./cli.js test/fixture/es2015.js --time-require --sorted
```

`--sorted` is optional. It sorts the requires from most expensive to least. The default is sequential sorting.

The output will display multiple `time-require` reports.
One for each forked process, and the last one for the main thread.