### PR TITLE
Prefer the locally installed version of AVA.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,6 +3,16 @@
 
 var debug = require('debug')('ava');
 
+// Prefer the local installation of AVA.
+var resolveFrom = require('resolve-from');
+var localCLI = resolveFrom('.', 'ava/cli');
+
+if (localCLI && localCLI !== __filename) {
+	debug('Using local install of AVA.');
+	require(localCLI);
+	return;
+}
+
 if (debug.enabled) {
 	require('time-require');
 }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "power-assert-renderers": "^0.1.0",
     "pretty-ms": "^2.0.0",
     "require-from-string": "^1.1.0",
-    "resolve-from": "^1.0.0",
+    "resolve-from": "^2.0.0",
     "serialize-error": "^1.1.0",
     "set-immediate-shim": "^1.0.1",
     "source-map-support": "^0.3.3",
@@ -128,5 +128,10 @@
         "test[/\\\\]"
       ]
     }
+  },
+  "xo": {
+    "ignore": [
+      "cli.js"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ $ ava --help
 
 Files starting with `_` are ignored. This can be useful for having helpers in the same directory as your test files.
 
+*WARNING: NON-STANDARD BEHAVIOR:* The AVA CLI will always try to find and use your projects local install of AVA. This is true even when you run the global `ava` command. This non-standard behavior solves an important [issue](https://github.com/sindresorhus/ava/issues/157), and should have no impact on everyday use.
 
 ## Documentation
 


### PR DESCRIPTION
This hunts for AVA in the locally installed project, and runs that
CLI instead of the globally installed one.

Fixes #157.