### PR TITLE
Add programmatic API

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,230 @@
+'use strict';
+var EventEmitter = require('events').EventEmitter;
+var path = require('path');
+var util = require('util');
+var fs = require('fs');
+var flatten = require('arr-flatten');
+var Promise = require('bluebird');
+var figures = require('figures');
+var assign = require('object-assign');
+var globby = require('globby');
+var chalk = require('chalk');
+var fork = require('./lib/fork');
+
+function Api(files, options) {
+	if (!(this instanceof Api)) {
+		return new Api(files, options);
+	}
+
+	EventEmitter.call(this);
+
+	assign(this, options);
+
+	this.rejectionCount = 0;
+	this.exceptionCount = 0;
+	this.passCount = 0;
+	this.failCount = 0;
+	this.fileCount = 0;
+	this.testCount = 0;
+	this.errors = [];
+	this.stats = [];
+	this.tests = [];
+	this.files = files || [];
+
+	Object.keys(Api.prototype).forEach(function (key) {
+		this[key] = this[key].bind(this);
+	}, this);
+}
+
+util.inherits(Api, EventEmitter);
+module.exports = Api;
+
+Api.prototype._runFile = function (file) {
+	var args = [file];
+
+	if (this.failFast) {
+		args.push('--fail-fast');
+	}
+
+	if (this.serial) {
+		args.push('--serial');
+	}
+
+	// Forward the `time-require` `--sorted` flag.
+	// Intended for internal optimization tests only.
+	if (this._sorted) {
+		args.push('--sorted');
+	}
+
+	return fork(args)
+		.on('stats', this._handleStats)
+		.on('test', this._handleTest)
+		.on('unhandledRejections', this._handleRejections)
+		.on('uncaughtException', this._handleExceptions);
+};
+
+Api.prototype._handleRejections = function (data) {
+	this.rejectionCount += data.rejections.length;
+
+	data.rejections.forEach(function (err) {
+		err.type = 'rejection';
+		err.file = data.file;
+		this.emit('error', err);
+		this.errors.push(err);
+	}, this);
+};
+
+Api.prototype._handleExceptions = function (err) {
+	this.exceptionCount++;
+	err.type = 'exception';
+	this.emit('error', err);
+	this.errors.push(err);
+};
+
+Api.prototype._handleStats = function (stats) {
+	this.testCount += stats.testCount;
+};
+
+Api.prototype._handleTest = function (test) {
+	test.title = this._prefixTitle(test.file) + test.title;
+
+	var isError = test.error.message;
+
+	if (isError) {
+		this.errors.push(test);
+	} else {
+		test.error = null;
+	}
+
+	this.emit('test', test);
+};
+
+Api.prototype._prefixTitle = function (file) {
+	if (this.fileCount === 1) {
+		return '';
+	}
+
+	var separator = ' ' + chalk.gray.dim(figures.pointerSmall) + ' ';
+
+	var base = path.dirname(this.files[0]);
+
+	if (base === '.') {
+		base = this.files[0] || 'test';
+	}
+
+	base += path.sep;
+
+	var prefix = path.relative('.', file)
+		.replace(base, '')
+		.replace(/\.spec/, '')
+		.replace(/test\-/g, '')
+		.replace(/\.js$/, '')
+		.split(path.sep)
+		.join(separator);
+
+	if (prefix.length > 0) {
+		prefix += separator;
+	}
+
+	return prefix;
+};
+
+Api.prototype.run = function () {
+	var self = this;
+
+	return handlePaths(this.files)
+		.map(function (file) {
+			return path.resolve(file);
+		})
+		.then(function (files) {
+			if (files.length === 0) {
+				return Promise.reject(new Error('Couldn\'t find any files to test'));
+			}
+
+			self.fileCount = files.length;
+
+			var tests = files.map(self._runFile);
+
+			// receive test count from all files and then run the tests
+			var statsCount = 0;
+			var deferred = Promise.pending();
+
+			tests.forEach(function (test) {
+				var counted = false;
+
+				function tryRun() {
+					if (counted) {
+						return;
+					}
+
+					if (++statsCount === self.fileCount) {
+						self.emit('ready');
+
+						var method = self.serial ? 'mapSeries' : 'map';
+
+						deferred.resolve(Promise[method](files, function (file, index) {
+							return tests[index].run();
+						}));
+					}
+				}
+
+				test.on('stats', tryRun);
+				test.catch(tryRun);
+			});
+
+			return deferred.promise;
+		})
+		.then(function (results) {
+			// assemble stats from all tests
+			self.stats = results.map(function (result) {
+				return result.stats;
+			});
+
+			self.tests = results.map(function (result) {
+				return result.tests;
+			});
+
+			self.tests = flatten(self.tests);
+
+			self.passCount = sum(self.stats, 'passCount');
+			self.failCount = sum(self.stats, 'failCount');
+		});
+};
+
+function handlePaths(files) {
+	if (files.length === 0) {
+		files = [
+			'test.js',
+			'test-*.js',
+			'test/*.js'
+		];
+	}
+
+	files.push('!**/node_modules/**');
+
+	// convert pinkie-promise to Bluebird promise
+	files = Promise.resolve(globby(files));
+
+	return files
+		.map(function (file) {
+			if (fs.statSync(file).isDirectory()) {
+				return handlePaths([path.join(file, '*.js')]);
+			}
+
+			return file;
+		})
+		.then(flatten)
+		.filter(function (file) {
+			return path.extname(file) === '.js' && path.basename(file)[0] !== '_';
+		});
+}
+
+function sum(arr, key) {
+	var result = 0;
+
+	arr.forEach(function (item) {
+		result += item[key];
+	});
+
+	return result;
+}

--- a/index.js
+++ b/index.js
@@ -66,8 +66,15 @@ function exit() {
 }
 
 globals.setImmediate(function () {
+	send('stats', {
+		testCount: runner.select({type: 'test'}).length
+	});
+
 	runner.on('test', test);
-	runner.run().then(exit);
+
+	process.on('ava-run', function () {
+		runner.run().then(exit);
+	});
 });
 
 module.exports = runner.test;

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -83,7 +83,7 @@ requireFromString(transpiled.code, testPath, {
 
 // if ava was not required, show an error
 if (!exports.avaRequired) {
-	throw new Error('No tests found in ' + testPath + ', make sure to import "ava" at the top of your test file');
+	send('no-tests');
 }
 
 // parse and re-emit ava messages

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -51,6 +51,12 @@ module.exports = function (args) {
 				reject(new Error('Test results were not received from: ' + file));
 			}
 		});
+
+		ps.on('no-tests', function () {
+			send(ps, 'teardown');
+
+			reject(new Error('No tests found in ' + path.relative('.', file) + ', make sure to import "ava" at the top of your test file'));
+		});
 	});
 
 	// emit `test` and `stats` events
@@ -78,6 +84,32 @@ module.exports = function (args) {
 
 	promise.on = function () {
 		ps.on.apply(ps, arguments);
+
+		return promise;
+	};
+
+	promise.send = function (name, data) {
+		send(ps, name, data);
+
+		return promise;
+	};
+
+	// send 'run' event only when fork is listening for it
+	var isReady = false;
+
+	ps.on('stats', function () {
+		isReady = true;
+	});
+
+	promise.run = function () {
+		if (isReady) {
+			send(ps, 'run');
+			return promise;
+		}
+
+		ps.on('stats', function () {
+			send(ps, 'run');
+		});
 
 		return promise;
 	};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -84,26 +84,13 @@ x.report = function (passed, failed, unhandled, uncaught) {
 	}
 };
 
-x.unhandledRejections = function (file, rejections) {
-	if (!(rejections && rejections.length)) {
-		return;
-	}
-
-	rejections.forEach(function (rejection) {
-		log.write(chalk.red('Unhandled Rejection: ', file));
-
-		if (rejection.stack) {
-			log.writelpad(chalk.red(beautifyStack(rejection.stack)));
-		} else {
-			log.writelpad(chalk.red(JSON.stringify(rejection)));
-		}
-
-		log.write();
-	});
+var types = {
+	rejection: 'Unhandled Rejection',
+	exception: 'Uncaught Exception'
 };
 
-x.uncaughtException = function (file, error) {
-	log.write(chalk.red('Uncaught Exception: ', file));
+x.unhandledError = function (type, file, error) {
+	log.write(chalk.red(types[type] + ':', file));
 
 	if (error.stack) {
 		log.writelpad(chalk.red(beautifyStack(error.stack)));

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -5,7 +5,6 @@ var Promise = require('bluebird');
 var hasFlag = require('has-flag');
 var Test = require('./test');
 var Hook = require('./hook');
-var send = require('./send');
 var objectAssign = require('object-assign');
 
 function noop() {}
@@ -183,11 +182,6 @@ Runner.prototype.run = function () {
 		passCount: 0,
 		testCount: serial.length + concurrent.length
 	};
-
-	// Runner is executed directly in tests, in that case `process.send() === undefined`
-	if (process.send) {
-		send('stats', stats);
-	}
 
 	return eachSeries(this.select({type: 'before', skipped: false}), this._runTest, this)
 		.catch(noop)

--- a/test/fork.js
+++ b/test/fork.js
@@ -11,6 +11,7 @@ test('emits test event', function (t) {
 	t.plan(1);
 
 	fork(fixture('generators.js'))
+		.run()
 		.on('test', function (tt) {
 			t.is(tt.title, 'generator function');
 			t.end();
@@ -23,6 +24,7 @@ test('resolves promise with tests info', function (t) {
 	var file = fixture('generators.js');
 
 	fork(file)
+		.run()
 		.then(function (info) {
 			t.is(info.stats.passCount, 1);
 			t.is(info.tests.length, 1);
@@ -35,6 +37,7 @@ test('rejects on error and streams output', function (t) {
 	t.plan(2);
 
 	fork(fixture('broken.js'))
+		.run()
 		.on('uncaughtException', function (data) {
 			t.true(/no such file or directory/.test(data.exception.message));
 		})
@@ -51,6 +54,7 @@ test('exit after tests are finished', function (t) {
 	var cleanupCompleted = false;
 
 	fork(fixture('long-running.js'))
+		.run()
 		.on('exit', function () {
 			t.true(Date.now() - start < 10000, 'test waited for a pending setTimeout');
 			t.true(cleanupCompleted, 'cleanup did not complete');
@@ -62,6 +66,7 @@ test('exit after tests are finished', function (t) {
 
 test('fake timers do not break duration', function (t) {
 	fork(fixture('fake-timers.js'))
+		.run()
 		.then(function (info) {
 			var duration = info.tests[0].duration;
 			t.true(duration < 1000, duration + ' < 1000');

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -298,6 +298,7 @@ test('don\'t display hook title if it did not fail', function (t) {
 	t.plan(2);
 
 	fork(path.join(__dirname, 'fixture', 'hooks-passing.js'))
+		.run()
 		.on('test', function (test) {
 			t.same(test.error, {});
 			t.is(test.title, 'pass');
@@ -311,6 +312,7 @@ test('display hook title if it failed', function (t) {
 	t.plan(2);
 
 	fork(path.join(__dirname, 'fixture', 'hooks-failing.js'))
+		.run()
 		.on('test', function (test) {
 			t.is(test.error.name, 'AssertionError');
 			t.is(test.title, 'beforeEach for "pass"');


### PR DESCRIPTION
This PR adds a long-awaited programmatic API (#83).

To-do:

- [x] resolve errors on node v0.10
- [ ] add tests
- [ ] use API in tests instead of `child_process.exec`
- [x] implement #282

It also opens a road for #27 (TAP support).