### PR TITLE
Put back AVA_APPVEYOR environment variable when running tests.

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -9,9 +9,15 @@ function execCli(args, cb) {
 		args = [args];
 	}
 
+	var env = {};
+
+	if (process.env.AVA_APPVEYOR) {
+		env.AVA_APPVEYOR = 1;
+	}
+
 	childProcess.execFile(process.execPath, ['../cli.js'].concat(args), {
 		cwd: __dirname,
-		env: {}
+		env: env
 	}, cb);
 }
 


### PR DESCRIPTION
Found the source of recent AppVeyor flakiness.

"someone" removed my fix. :smile: 