### PR TITLE
Force serial execution of child processes on --serial flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -212,8 +212,8 @@ function init(files) {
 
 			fileCount = files.length;
 
-            return cli.flags.serial ? Promise.mapSeries(files, run)
-                : Promise.all(files.map(run));
+			return cli.flags.serial ? Promise.mapSeries(files, run)
+				: Promise.all(files.map(run));
 		});
 }
 

--- a/cli.js
+++ b/cli.js
@@ -212,9 +212,8 @@ function init(files) {
 
 			fileCount = files.length;
 
-			var tests = files.map(run);
-
-			return Promise.all(tests);
+            return cli.flags.serial ? Promise.mapSeries(files, run)
+                : Promise.all(files.map(run));
 		});
 }
 


### PR DESCRIPTION
This forces serial execution of child processes if --serial flag is specified.

Without control over concurrency test suites are unable to instantiate identical fixtures in a shared database.

Ideally this must be a property of a test suite, e.g.:

test.serialSuite() // Force serial execution of a test suite