### PR TITLE
Don't crash when there's no local AVA

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,10 +5,13 @@ var debug = require('debug')('ava');
 
 // Prefer the local installation of AVA.
 var resolveFrom = require('resolve-from');
-var localCLI = resolveFrom('.', 'ava/cli');
 
-if (localCLI && localCLI !== __filename) {
-	debug('Using local install of AVA.');
+try {
+	var localCLI = resolveFrom('.', 'ava/cli');
+} catch (_) {}
+
+if (localCLI && localCLI !== _filename) {
+	debug('Using local install of AVA');
 	require(localCLI);
 	return;
 }


### PR DESCRIPTION
When there's no local `ava` installed, global CLI crashes:

<img width="648" alt="screen shot 2015-11-29 at 6 55 35 pm" src="https://cloud.githubusercontent.com/assets/697676/11458931/d1eaff46-96ca-11e5-85be-6ed0d0582888.png">
