### PR TITLE
Hide test internals. Fixes #252.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -41,10 +41,6 @@ function Test(title, fn) {
 	if (this.title === 'callee$0$0') {
 		this.title = '[anonymous]';
 	}
-
-	Object.keys(Test.prototype).forEach(function (key) {
-		this[key] = this[key].bind(this);
-	}, this);
 }
 
 module.exports = Test;
@@ -52,33 +48,6 @@ module.exports = Test;
 Test.prototype._assert = function () {
 	this.assertCount++;
 };
-
-// patch assert methods to increase assert count and store errors
-Object.keys(assert).forEach(function (el) {
-	Test.prototype[el] = function () {
-		var self = this;
-
-		try {
-			var fn = assert[el].apply(assert, arguments);
-
-			fn = observableToPromise(fn);
-
-			if (isPromise(fn)) {
-				return Promise.resolve(fn)
-					.catch(function (err) {
-						self._setAssertError(err);
-					})
-					.finally(function () {
-						self._assert();
-					});
-			}
-		} catch (err) {
-			this._setAssertError(err);
-		}
-
-		this._assert();
-	};
-});
 
 Test.prototype._setAssertError = function (err) {
 	if (this.assertError !== undefined) {
@@ -128,7 +97,7 @@ Test.prototype.run = function () {
 	var ret;
 
 	try {
-		ret = this.fn(this);
+		ret = this.fn(this._publicApi());
 	} catch (err) {
 		this._setAssertError(err);
 		this.exit();
@@ -171,7 +140,7 @@ Test.prototype.run = function () {
 Object.defineProperty(Test.prototype, 'end', {
 	get: function () {
 		if (this.metadata.callback) {
-			return this._end;
+			return this._end.bind(this);
 		}
 		throw new Error('t.end is not supported in this context. To use t.end as a callback, you must use "callback mode" via `test.cb(testName, fn)` ');
 	}
@@ -229,4 +198,67 @@ Test.prototype.exit = function () {
 			self.promise.resolve(self);
 		});
 	}
+};
+
+Test.prototype._publicApi = function () {
+	var self = this;
+	var api = {};
+
+	// Getters
+	[
+		'assertCount',
+		'title',
+		'end',
+		'_capt',
+		'_expr'
+	]
+		.forEach(function (name) {
+			Object.defineProperty(api, name, {
+				enumerable: !/^_/.test(name),
+				get: function () {
+					return self[name];
+				}
+			});
+		});
+
+	// Get / Set
+	Object.defineProperty(api, 'context', {
+		enumerable: true,
+		get: function () {
+			return self.context;
+		},
+		set: function (context) {
+			self.context = context;
+		}
+	});
+
+	// Bound Functions
+	api.plan = this.plan.bind(this);
+
+	// Patched assert methods: increase assert count and store errors.
+	Object.keys(assert).forEach(function (el) {
+		api[el] = function () {
+			try {
+				var fn = assert[el].apply(assert, arguments);
+
+				fn = observableToPromise(fn);
+
+				if (isPromise(fn)) {
+					return Promise.resolve(fn)
+						.catch(function (err) {
+							self._setAssertError(err);
+						})
+						.finally(function () {
+							self._assert();
+						});
+				}
+			} catch (err) {
+				self._setAssertError(err);
+			}
+
+			self._assert();
+		};
+	});
+
+	return api;
 };


### PR DESCRIPTION
I considered the delegates module, but that still requires exposing the Test
object itself as a member of `api`, and does not bind `this` for the exposed
functions.

Fixes #252.