### PR TITLE
Add aliases to .true and .false: .isTrue and .isFalse

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -40,10 +40,12 @@ x.notOk = function (val, msg) {
 	test(!val, create(val, false, '==', msg, x.notOk));
 };
 
+x.isTrue =
 x.true = function (val, msg) {
 	test(val === true, create(val, true, '===', msg, x.true));
 };
 
+x.isFalse =
 x.false = function (val, msg) {
 	test(val === false, create(val, false, '===', msg, x.false));
 };

--- a/test/assert.js
+++ b/test/assert.js
@@ -70,6 +70,30 @@ test('.true()', function (t) {
 	t.end();
 });
 
+test('.isTrue()', function (t) {
+	t.throws(function () {
+		assert.isTrue(1);
+	});
+
+	t.throws(function () {
+		assert.isTrue(0);
+	});
+
+	t.throws(function () {
+		assert.isTrue(false);
+	});
+
+	t.throws(function () {
+		assert.isTrue('foo');
+	});
+
+	t.doesNotThrow(function () {
+		assert.isTrue(true);
+	});
+
+	t.end();
+});
+
 test('.false()', function (t) {
 	t.throws(function () {
 		assert.false(0);
@@ -89,6 +113,30 @@ test('.false()', function (t) {
 
 	t.doesNotThrow(function () {
 		assert.false(false);
+	});
+
+	t.end();
+});
+
+test('.isFalse()', function (t) {
+	t.throws(function () {
+		assert.isFalse(0);
+	});
+
+	t.throws(function () {
+		assert.isFalse(1);
+	});
+
+	t.throws(function () {
+		assert.isFalse(true);
+	});
+
+	t.throws(function () {
+		assert.isFalse('foo');
+	});
+
+	t.doesNotThrow(function () {
+		assert.isFalse(false);
 	});
 
 	t.end();


### PR DESCRIPTION
Aliases for `.true` and `.false`, for cases where they act like tokens instead of functions (such as destructuring): `.isTrue` and `.isFalse`.

Related #288