### PR TITLE
WIP - allow custom pre-processors

### DIFF
--- a/api.js
+++ b/api.js
@@ -50,6 +50,12 @@ Api.prototype._runFile = function (file) {
 		args.push('--serial');
 	}
 
+	if (this.compilers) {
+		Object.keys(this.compilers).forEach(function (ext) {
+			args.push('--compilers=' + ext + ':' + this.compilers[ext]);
+		}, this);
+	}
+
 	// Forward the `time-require` `--sorted` flag.
 	// Intended for internal optimization tests only.
 	if (this._sorted) {
@@ -217,7 +223,7 @@ function handlePaths(files) {
 		})
 		.then(flatten)
 		.filter(function (file) {
-			return path.extname(file) === '.js' && path.basename(file)[0] !== '_';
+			return path.extname(file) === '.coffee' || path.extname(file) === '.js' && path.basename(file)[0] !== '_';
 		});
 }
 

--- a/cli.js
+++ b/cli.js
@@ -62,10 +62,27 @@ if (cli.flags.init) {
 
 log.write();
 
-var api = new Api(cli.input, {
+var apiOpts = {
 	failFast: cli.flags.failFast,
 	serial: cli.flags.serial
-});
+};
+
+if (cli.flags.compilers) {
+	var compilers = cli.flags.compilers;
+	if (!Array.isArray(compilers)) {
+		compilers = [compilers];
+	}
+	apiOpts.compilers = {};
+	compilers.forEach(function (compilerDef) {
+		var colonIdx = compilerDef.indexOf(':');
+		if (colonIdx === -1) {
+			throw new Error('compilers must be specified with: --compilers=<ext>:<require-path>');
+		}
+		apiOpts.compilers[compilerDef.substring(0, colonIdx)] = compilerDef.substring(colonIdx + 1);
+	});
+}
+
+var api = new Api(cli.input, apiOpts);
 
 api.on('test', function (test) {
 	if (test.error) {

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -30,6 +30,8 @@ var loudRejection = require('loud-rejection/api')(process);
 var resolveFrom = require('resolve-from');
 var hasGenerator = require('has-generator');
 var serializeError = require('serialize-error');
+var path = require('path');
+var fs = require('fs');
 var send = require('./send');
 
 var testPath = process.argv[2];
@@ -55,7 +57,8 @@ var options = {
 	optional: hasGenerator ? ['asyncToGenerator', 'runtime'] : ['runtime'],
 	plugins: [powerAssert],
 	sourceMaps: true,
-	inputSourceMap: null
+	inputSourceMap: null,
+	filename: testPath
 };
 
 // check if test files required ava and show error, when they didn't
@@ -74,8 +77,33 @@ if (inputSourceMap) {
 	options.inputSourceMap = JSON.parse(inputSourceMap.map);
 }
 
+// load up custom compilers
+process.argv.slice(3).forEach(function (arg) {
+	var match = /^--compilers=.+?:(.+)$/i.exec(arg);
+	if (match) {
+		require(match[1]);
+	}
+});
+
 // include test file
-var transpiled = babel.transformFileSync(testPath, options);
+var Module = module.constructor;
+var source = fs.readFileSync(testPath, 'utf8');
+var extension = path.extname(testPath);
+
+var compiler = Module._extensions[extension];
+if (compiler) {
+	compiler(
+		{
+			_compile: function (s, f) {
+				source = s;
+				testPath = f;
+			}
+		},
+		testPath
+	);
+}
+
+var transpiled = babel.transform(source, options);
 sourceMapCache[testPath] = transpiled.map;
 requireFromString(transpiled.code, testPath, {
 	appendPaths: module.paths

--- a/package.json
+++ b/package.json
@@ -115,7 +115,9 @@
     "update-notifier": "^0.5.0"
   },
   "devDependencies": {
+    "coffee-script": "^1.10.0",
     "coveralls": "^2.11.4",
+    "delay": "^1.1.0",
     "signal-exit": "^2.1.2",
     "sinon": "^1.17.2",
     "tap": "^2.2.1",

--- a/test/fixture/custom-preprocessor.coffee
+++ b/test/fixture/custom-preprocessor.coffee
@@ -1,0 +1,5 @@
+test = require "../../"
+delay = require "delay"
+
+test "peter", (t) ->
+	yield delay 200


### PR DESCRIPTION
This adds custom preprocessor support.

No automated test yet. Run the demo like this:

    ./cli.js --compilers=coffee:cofee-script/register ./test/fixture/custom-processor.coffee

Currently it runs our own Babel transform on the coffee-script transpiled code.  This allows the use of generators, async/await, etc. without users having to manually configure Babel. I am not sure this is the right strategy. While it provides an easy path to use ES2015 goodness in your coffee-script tests, there will likely be scenarios where users want to specify their own Babel setup, and just use our runner.

 1. Should we include a flag to disable our Babel hooks?
 2. Should automatically disable our Babel hook when we see `--compilers=` or `--require=`?
 3. If we do **2**, should we provide a way to reenable?