### PR TITLE
Fix regression in uncaughtException formatting.

### DIFF
--- a/api.js
+++ b/api.js
@@ -74,9 +74,11 @@ Api.prototype._handleRejections = function (data) {
 	}, this);
 };
 
-Api.prototype._handleExceptions = function (err) {
+Api.prototype._handleExceptions = function (data) {
 	this.exceptionCount++;
+	var err = data.exception;
 	err.type = 'exception';
+	err.file = data.file;
 	this.emit('error', err);
 	this.errors.push(err);
 };


### PR DESCRIPTION
c424ceb3d introduced a regression in how we format uncaughtExceptions.
The wrong value was being passed to the logger.