### PR TITLE
Unify how files with no tests are reported.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,15 @@ function exit() {
 }
 
 globals.setImmediate(function () {
+	var numberOfTests = runner.select({type: 'test'}).length;
+
+	if (numberOfTests === 0) {
+		send('no-tests', {avaRequired: true});
+		return;
+	}
+
 	send('stats', {
-		testCount: runner.select({type: 'test'}).length
+		testCount: numberOfTests
 	});
 
 	runner.on('test', test);

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -83,7 +83,7 @@ requireFromString(transpiled.code, testPath, {
 
 // if ava was not required, show an error
 if (!exports.avaRequired) {
-	send('no-tests');
+	send('no-tests', {avaRequired: false});
 }
 
 // parse and re-emit ava messages

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -36,26 +36,19 @@ module.exports = function (args) {
 			}
 
 			if (testResults) {
-				if (testResults.tests.length === 0) {
-					testResults.stats.failCount = 1;
-					testResults.tests.push({
-						duration: 0,
-						title: file,
-						error: new Error('No tests for ' + file),
-						type: 'test'
-					});
-				}
-
 				resolve(testResults);
 			} else {
 				reject(new Error('Test results were not received from: ' + file));
 			}
 		});
 
-		ps.on('no-tests', function () {
+		ps.on('no-tests', function (data) {
 			send(ps, 'teardown');
-
-			reject(new Error('No tests found in ' + path.relative('.', file) + ', make sure to import "ava" at the top of your test file'));
+			var message = 'No tests found in ' + path.relative('.', file);
+			if (!data.avaRequired) {
+				message += ', make sure to import "ava" at the top of your test file';
+			}
+			reject(new Error(message));
 		});
 	});
 


### PR DESCRIPTION
There are two possible errors that can result in no test data being
received.

 1. The user never imports `ava` in their test file.
 2. The user has not written any tests in the file yet.

We treat both as errors, but were handling them differently.
Most problematic, one caused the promise to resolve, the other
caused the promise to reject.