### PR TITLE
Node.js-style --require CLI argument

### DIFF
--- a/api.js
+++ b/api.js
@@ -18,6 +18,7 @@ function Api(files, options) {
 	EventEmitter.call(this);
 
 	this.options = options || {};
+
 	this.rejectionCount = 0;
 	this.exceptionCount = 0;
 	this.passCount = 0;

--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,7 @@ if (debug.enabled) {
 	require('time-require');
 }
 
+var arrify = require('arrify');
 var meow = require('meow');
 var updateNotifier = require('update-notifier');
 var chalk = require('chalk');
@@ -35,6 +36,7 @@ var cli = meow([
 	'  --init       Add AVA to your project',
 	'  --fail-fast  Stop after first test failure',
 	'  --serial     Run tests serially',
+	'  --require    Module to preload (Can be repeated)',
 	'',
 	'Examples',
 	'  ava',
@@ -46,7 +48,10 @@ var cli = meow([
 	'Default patterns when no arguments:',
 	'test.js test-*.js test/*.js'
 ], {
-	string: ['_'],
+	string: [
+		'_',
+		'require'
+	],
 	boolean: [
 		'fail-fast',
 		'serial'
@@ -64,7 +69,8 @@ log.write();
 
 var api = new Api(cli.input, {
 	failFast: cli.flags.failFast,
-	serial: cli.flags.serial
+	serial: cli.flags.serial,
+	require: arrify(cli.flags.require)
 });
 
 api.on('test', function (test) {

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -16,6 +16,11 @@ if (debug.enabled) {
 // Bind globals first, before anything has a chance to interfere.
 var globals = require('./globals');
 
+var resolveCwd = require('resolve-cwd');
+(opts.require || []).forEach(function (moduleId) {
+	require(resolveCwd(moduleId));
+});
+
 var sourceMapCache = Object.create(null);
 
 var sourceMapSupport = require('source-map-support');
@@ -33,7 +38,6 @@ sourceMapSupport.install({
 var createEspowerPlugin = require('babel-plugin-espower/create');
 var requireFromString = require('require-from-string');
 var loudRejection = require('loud-rejection/api')(process);
-var resolveCwd = require('resolve-cwd');
 var hasGenerator = require('has-generator');
 var serializeError = require('serialize-error');
 var send = require('./send');

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   ],
   "dependencies": {
     "arr-flatten": "^1.0.1",
+    "arrify": "^1.0.0",
     "ava-init": "^0.1.0",
     "babel-core": "^5.8.23",
     "babel-plugin-espower": "^1.1.0",

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ $ ava --help
     --init       Add AVA to your project
     --fail-fast  Stop after first test failure
     --serial     Run tests serially
+    --require    Module to preload (Can be repeated)
 
   Examples
     ava

--- a/test/api.js
+++ b/test/api.js
@@ -260,3 +260,17 @@ test('test file in node_modules is ignored', function (t) {
 			t.true(/Couldn't find any files to test/.test(err.message));
 		});
 });
+
+test('Node.js-style --require CLI argument', function (t) {
+	t.plan(1);
+
+	var api = new Api(
+		[path.join(__dirname, 'fixture/validate-installed-global.js')],
+		{require: [path.join(__dirname, 'fixture', 'install-global.js')]}
+	);
+
+	api.run()
+		.then(function () {
+			t.is(api.passCount, 1);
+		});
+});

--- a/test/fixture/install-global.js
+++ b/test/fixture/install-global.js
@@ -1,0 +1,1 @@
+global.foo = 'bar';

--- a/test/fixture/validate-installed-global.js
+++ b/test/fixture/validate-installed-global.js
@@ -1,0 +1,3 @@
+import test from '../../';
+
+test(t => t.is(global.foo, 'bar'));


### PR DESCRIPTION
I figured I'd have an attempt at being able to pass the `--require` through to the Node executable used for the child process (#229).

My test project uses `import` and `export`, so doesn't execute in Node v5 without babel/register. I can manually confirm using `npm link` that the changes I have so far function as expected.

Besides general comments (very much appreciated), I'm a little bit at a loss as where to start with the tests. Do I need to confirm (with tests) that the `ava --require moduleId` works? Or is it sufficient to use mocks and confirm that arguments are being passed through as expected?