### PR TITLE
Display skipped tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function exit() {
 }
 
 globals.setImmediate(function () {
-	var numberOfTests = runner.select({type: 'test'}).length;
+	var numberOfTests = runner.select({type: 'test', skipped: false}).length;
 
 	if (numberOfTests === 0) {
 		send('no-tests', {avaRequired: true});

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -87,7 +87,7 @@ Runner.prototype._addFn = function (opts, title, fn) {
 };
 
 Runner.prototype._runTestWithHooks = function (test) {
-	if (test.skip) {
+	if (test.metadata.skipped) {
 		return this._addTestResult(test);
 	}
 
@@ -95,9 +95,9 @@ Runner.prototype._runTestWithHooks = function (test) {
 		return hook.test(test.title);
 	}
 
-	var tests = this.select({type: 'beforeEach', skipped: false}).map(hookToTest);
+	var tests = this.select({type: 'beforeEach'}).map(hookToTest);
 	tests.push(test);
-	tests.push.apply(tests, this.select({type: 'afterEach', skipped: false}).map(hookToTest));
+	tests.push.apply(tests, this.select({type: 'afterEach'}).map(hookToTest));
 
 	var context = {};
 
@@ -120,6 +120,10 @@ Runner.prototype._runTest = function (test) {
 
 	// add test result regardless of state
 	// but on error, don't execute next tests
+	if (test.metadata.skipped) {
+		return this._addTestResult(test);
+	}
+
 	return test.run().finally(function () {
 		self._addTestResult(test);
 	});
@@ -147,7 +151,7 @@ Runner.prototype._addTestResult = function (test) {
 		title: test.title,
 		error: test.assertError,
 		type: test.metadata.type,
-		skip: test.skip
+		skip: test.metadata.skipped
 	};
 
 	this.results.push(props);
@@ -165,25 +169,28 @@ Runner.prototype.run = function () {
 
 	var serial = this.select({
 		exclusive: hasExclusive,
-		skipped: false,
 		serial: true,
 		type: 'test'
 	});
 
 	var concurrent = this.select({
 		exclusive: hasExclusive,
-		skipped: false,
 		serial: false,
 		type: 'test'
+	});
+
+	var skipped = this.select({
+		type: 'test',
+		skipped: true
 	});
 
 	var stats = this.stats = {
 		failCount: 0,
 		passCount: 0,
-		testCount: serial.length + concurrent.length
+		testCount: serial.length + concurrent.length - skipped.length
 	};
 
-	return eachSeries(this.select({type: 'before', skipped: false}), this._runTest, this)
+	return eachSeries(this.select({type: 'before'}), this._runTest, this)
 		.catch(noop)
 		.then(function () {
 			if (stats.failCount > 0) {
@@ -197,7 +204,7 @@ Runner.prototype.run = function () {
 			return self._runConcurrent(concurrent);
 		})
 		.then(function () {
-			return eachSeries(self.select({type: 'after', skipped: false}), self._runTest, self);
+			return eachSeries(self.select({type: 'after'}), self._runTest, self);
 		})
 		.catch(noop)
 		.then(function () {

--- a/test/runner.js
+++ b/test/runner.js
@@ -218,6 +218,46 @@ test('anything can be skipped', function (t) {
 	});
 });
 
+test('include skipped tests in results', function (t) {
+	var runner = new Runner();
+
+	runner.before('before', noop);
+	runner.before.skip('before.skip', noop);
+
+	runner.beforeEach('beforeEach', noop);
+	runner.beforeEach.skip('beforeEach.skip', noop);
+
+	runner.test.serial('test', noop);
+	runner.test.serial.skip('test.skip', noop);
+
+	runner.after('after', noop);
+	runner.after.skip('after.skip', noop);
+
+	runner.afterEach('afterEach', noop);
+	runner.afterEach.skip('afterEach.skip', noop);
+
+	runner.run().then(function () {
+		var titles = runner.results.map(function (result) {
+			return result.title;
+		});
+
+		t.same(titles, [
+			'before',
+			'before.skip',
+			'beforeEach',
+			'beforeEach.skip',
+			'test',
+			'afterEach',
+			'afterEach.skip',
+			'test.skip',
+			'after',
+			'after.skip'
+		]);
+
+		t.end();
+	});
+});
+
 test('test types and titles', function (t) {
 	t.plan(10);
 


### PR DESCRIPTION
Fix regression introduced in #243. Skipped tests were ignored and not displayed in the output. This PR brings back skipped tests:

<img width="154" alt="screen shot 2015-12-03 at 12 08 31 pm" src="https://cloud.githubusercontent.com/assets/697676/11559075/a5268e5a-99b6-11e5-9b81-08f422b91134.png">
