### PR TITLE
Do not mask RangeError when comparing circular values.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -60,7 +60,10 @@ x.same = function (val, expected, msg) {
 	try {
 		assert.deepStrictEqual(val, expected, msg);
 	} catch (err) {
-		test(false, create(val, expected, '===', msg, x.same));
+		if (err instanceof assert.AssertionError) {
+			test(false, create(val, expected, '===', msg, x.same));
+		}
+		throw err;
 	}
 };
 
@@ -68,7 +71,10 @@ x.notSame = function (val, expected, msg) {
 	try {
 		assert.notDeepStrictEqual(val, expected, msg);
 	} catch (err) {
-		test(false, create(val, expected, '!==', msg, x.notSame));
+		if (err instanceof assert.AssertionError) {
+			test(false, create(val, expected, '!==', msg, x.notSame));
+		}
+		throw err;
 	}
 };
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -219,3 +219,29 @@ test('.ifError()', function (t) {
 
 	t.end();
 });
+
+var Circular = function () {
+	this.test = this;
+};
+
+test('.same() should not mask RangeError from underlying assert', function (t) {
+	try {
+		var a = new Circular();
+		var b = new Circular();
+		assert.same(a, b);
+	} catch (e) {
+		t.is(e.name, 'RangeError');
+		t.end();
+	}
+});
+
+test('.notSame() should not mask RangeError from underlying assert', function (t) {
+	try {
+		var a = new Circular();
+		var b = new Circular();
+		assert.notSame(a, b);
+	} catch (e) {
+		t.is(e.name, 'RangeError');
+		t.end();
+	}
+});


### PR DESCRIPTION
#300 has an alternate solution (allow circular comparison).

Fixes: #298