### PR TITLE
Allow deepEqual comparison of values with circular references. Fixes #298.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,5 +1,6 @@
 'use strict';
 var assert = require('core-assert');
+var deepEqual = require('deeper');
 var observableToPromise = require('observable-to-promise');
 var isPromise = require('is-promise');
 var x = module.exports;
@@ -57,19 +58,11 @@ x.not = function (val, expected, msg) {
 };
 
 x.same = function (val, expected, msg) {
-	try {
-		assert.deepStrictEqual(val, expected, msg);
-	} catch (err) {
-		test(false, create(val, expected, '===', msg, x.same));
-	}
+	test(deepEqual(val, expected), create(val, expected, '===', msg, x.same));
 };
 
 x.notSame = function (val, expected, msg) {
-	try {
-		assert.notDeepStrictEqual(val, expected, msg);
-	} catch (err) {
-		test(false, create(val, expected, '!==', msg, x.notSame));
-	}
+	test(!deepEqual(val, expected), create(val, expected, '!==', msg, x.notSame));
 };
 
 x.throws = function (fn, err, msg) {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "co-with-promise": "^4.6.0",
     "core-assert": "^0.1.0",
     "debug": "^2.2.0",
+    "deeper": "^2.1.0",
     "empower": "^1.1.0",
     "figures": "^1.4.0",
     "fn-name": "^2.0.0",

--- a/test/assert.js
+++ b/test/assert.js
@@ -219,3 +219,22 @@ test('.ifError()', function (t) {
 
 	t.end();
 });
+
+test('.same() should not mask RangeError from underlying assert', function (t) {
+	var Circular = function () {
+		this.test = this;
+	};
+
+	var a = new Circular();
+	var b = new Circular();
+
+	t.throws(function () {
+		assert.notSame(a, b);
+	});
+
+	t.doesNotThrow(function () {
+		assert.same(a, b);
+	});
+
+	t.end();
+});


### PR DESCRIPTION
Introduces an additional dependency: `deeper`.

Fixes #298.

Alternate to #300.