### PR TITLE
allow destructuring of `t` parameter.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -214,7 +214,7 @@ Test.prototype._publicApi = function () {
 	]
 		.forEach(function (name) {
 			Object.defineProperty(api, name, {
-				enumerable: !/^_/.test(name),
+				enumerable: name === 'end' ? self.metadata.callback : true,
 				get: function () {
 					return self[name];
 				}

--- a/test/fixture/destructuring-public-api.js
+++ b/test/fixture/destructuring-public-api.js
@@ -1,0 +1,17 @@
+import test from '../../';
+
+test.beforeEach(t => t.context = 'bar');
+
+test.cb('callback mode', ({context: foo, ... t}) => {
+	t.is(foo, 'bar');
+	t.end();
+});
+
+test.cb('callback mode', ({context: foo, end, ... t}) => {
+	t.is(foo, 'bar');
+	end();
+});
+
+test('sync', ({context: foo, ... t}) => {
+	t.is(foo, 'bar');
+});

--- a/test/fork.js
+++ b/test/fork.js
@@ -75,3 +75,13 @@ test('fake timers do not break duration', function (t) {
 			t.end();
 		});
 });
+
+test('destructuring of `t` is allowed', function (t) {
+	fork(fixture('destructuring-public-api.js'))
+		.run()
+		.then(function (info) {
+			t.is(info.stats.failCount, 0);
+			t.is(info.stats.passCount, 3);
+			t.end();
+		});
+});


### PR DESCRIPTION
There were two problems with using destructuring on the `t` parameter passed to tests:

 1. `t.end` is enumerable, but throws when accessed. 
This created problems when destructuring using rest params `{ok, ...t}`. 
The solution: `t.end` is enumerable only in "callback mode".

 2. `t._capt`, `t._expr` are not enumerable, 
and therefore not exposed as a member of the `...t` rest param.
 The only solution was to make them enumerable. 
Not ideal, but better than the confusing error that previously occurred.