### PR TITLE
Adds filename to failed test title.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -91,7 +91,7 @@ api.run()
 		log.write();
 
 		if (api.failCount > 0) {
-			log.errors(api.tests);
+			log.errors(api.errors);
 		}
 
 		process.stdout.write('');

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -52,18 +52,14 @@ x.test = function (props) {
 	log.success(props.title + dur);
 };
 
-x.errors = function (results) {
+x.errors = function (tests) {
 	var i = 0;
 
-	results.forEach(function (result) {
-		if (!(result.error && result.error.message)) {
-			return;
-		}
-
+	tests.forEach(function (test) {
 		i++;
 
-		log.writelpad(chalk.red(i + '.', result.title));
-		log.writelpad(chalk.red(beautifyStack(result.error.stack)));
+		log.writelpad(chalk.red(i + '.', test.title));
+		log.writelpad(chalk.red(beautifyStack(test.error.stack)));
 		log.write();
 	});
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -94,7 +94,7 @@ test('display filename prefixes for failed test stack traces', function (t) {
 
 	execCli(['fixture/es2015.js', 'fixture/one-pass-one-fail.js'], function (err, stdout, stderr) {
 		t.ok(err);
-		t.match(stderr, /^.*1\. one-pass-one-fail › this is a failing test.*$/m);
+		t.match(stderr, /^.*1\. one-pass-one-fail.*this is a failing test.*$/m);
 		t.end();
 	});
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -89,6 +89,16 @@ test('display test title prefixes', function (t) {
 	});
 });
 
+test('display filename prefixes for failed test stack traces', function (t) {
+	t.plan(2);
+
+	execCli(['fixture/es2015.js', 'fixture/one-pass-one-fail.js'], function (err, stdout, stderr) {
+		t.ok(err);
+		t.match(stderr, /1. one-pass-one-fail › this is a failing test/);
+		t.end();
+	});
+});
+
 test('don\'t display test title if there is only one anonymous test', function (t) {
 	t.plan(2);
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -94,7 +94,7 @@ test('display filename prefixes for failed test stack traces', function (t) {
 
 	execCli(['fixture/es2015.js', 'fixture/one-pass-one-fail.js'], function (err, stdout, stderr) {
 		t.ok(err);
-		t.match(stderr, /1. one-pass-one-fail › this is a failing test/);
+		t.match(stderr, /^.*1\. one-pass-one-fail › this is a failing test.*$/m);
 		t.end();
 	});
 });


### PR DESCRIPTION
Addresses #272 by sending the logger the tests stored in *api.errors*, which already include the formatted file prefix in their titles, instead of the whole list included in *api.tests*.