### PR TITLE
process is forked with a single JSON argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var relative = require('path').relative;
-var hasFlag = require('has-flag');
 var chalk = require('chalk');
 var serializeError = require('serialize-error');
 var globals = require('./lib/globals');
@@ -8,10 +7,12 @@ var Runner = require('./lib/runner');
 var send = require('./lib/send');
 var log = require('./lib/logger');
 
-var runner = new Runner();
-
 // note that test files have require('ava')
 require('./lib/babel').avaRequired = true;
+
+var opts = JSON.parse(process.argv[2]);
+
+var runner = new Runner(opts);
 
 // check if the test is being run without AVA cli
 var isForked = typeof process.send === 'function';
@@ -45,7 +46,7 @@ function test(props) {
 
 	send('test', props);
 
-	if (props.error && hasFlag('fail-fast')) {
+	if (props.error && opts.failFast) {
 		isFailed = true;
 		exit();
 	}

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -2,7 +2,14 @@
 
 var debug = require('debug')('ava');
 
+var opts = JSON.parse(process.argv[2]);
+
 if (debug.enabled) {
+	// Forward the `time-require` `--sorted` flag.
+	// Intended for internal optimization tests only.
+	if (opts._sorted) {
+		process.argv.push('--sorted');
+	}
 	require('time-require');
 }
 
@@ -31,7 +38,7 @@ var hasGenerator = require('has-generator');
 var serializeError = require('serialize-error');
 var send = require('./send');
 
-var testPath = process.argv[2];
+var testPath = opts.file;
 
 // include local babel and fallback to ava's babel
 var babel;

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -1,22 +1,21 @@
 'use strict';
 var childProcess = require('child_process');
 var path = require('path');
+var objectAssign = require('object-assign');
 var Promise = require('bluebird');
 var debug = require('debug')('ava');
 var send = require('./send');
 
-module.exports = function (args) {
-	if (!Array.isArray(args)) {
-		args = [args];
-	}
-
+module.exports = function (file, opts) {
 	var filepath = path.join(__dirname, 'babel.js');
-	var file = args[0];
+	opts = objectAssign({file: file}, opts);
 
 	var options = {
 		cwd: path.dirname(file),
 		stdio: ['ignore', process.stderr, process.stderr]
 	};
+
+	var args = [JSON.stringify(opts)];
 
 	var ps = childProcess.fork(filepath, args, options);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -2,7 +2,6 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var Promise = require('bluebird');
-var hasFlag = require('has-flag');
 var Test = require('./test');
 var Hook = require('./hook');
 var objectAssign = require('object-assign');
@@ -23,6 +22,8 @@ function Runner(opts) {
 	}
 
 	EventEmitter.call(this);
+
+	this.options = opts || {};
 
 	this.results = [];
 	this.tests = [];
@@ -130,7 +131,7 @@ Runner.prototype._runTest = function (test) {
 };
 
 Runner.prototype._runConcurrent = function (tests) {
-	if (hasFlag('serial')) {
+	if (this.options.serial) {
 		return this._runSerial(tests);
 	}
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "figures": "^1.4.0",
     "fn-name": "^2.0.0",
     "globby": "^4.0.0",
-    "has-flag": "^1.0.0",
     "has-generator": "^1.0.0",
     "is-generator-fn": "^1.0.0",
     "is-observable": "^0.1.0",


### PR DESCRIPTION
This PR attempts to fix #318 .

Initially, the JSON string is converted back into `process.argv` values in lib/babel.js. I'm happy to go further and actually try to eliminate `--fail-fast` and `--serial` altogether in the child process, but I figured it was worth sharing what I had so far.