### PR TITLE
don't use local Babel directly

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -33,22 +33,12 @@ sourceMapSupport.install({
 var createEspowerPlugin = require('babel-plugin-espower/create');
 var requireFromString = require('require-from-string');
 var loudRejection = require('loud-rejection/api')(process);
-var resolveCwd = require('resolve-cwd');
 var hasGenerator = require('has-generator');
 var serializeError = require('serialize-error');
+var babel = require('babel-core');
 var send = require('./send');
 
 var testPath = opts.file;
-
-// include local babel and fallback to ava's babel
-var babel;
-
-try {
-	var localBabel = resolveCwd('babel-core') || resolveCwd('babel');
-	babel = require(localBabel);
-} catch (err) {
-	babel = require('babel-core');
-}
 
 // initialize power-assert
 var powerAssert = createEspowerPlugin(babel, {

--- a/readme.md
+++ b/readme.md
@@ -363,16 +363,7 @@ test(t => {
 });
 ```
 
-You can also use your own local Babel version:
-
-```json
-{
-	"devDependencies": {
-		"ava": "^0.6.0",
-		"babel-core": "^5.8.0"
-	}
-}
-```
+We don't yet [support Babel 6](https://github.com/sindresorhus/ava/pull/221), but you can use any Babel version in your project. We use our own bundled one.
 
 #### Transpiling Imported Modules
 


### PR DESCRIPTION
Instead depend on npm to dedupe. This is better as we will no longer fail if the user has Babel 6 and we Babel 5, and npm just won't dedupe. Same situation in the future when we're on Babel 6, but the user is still on Babel 5.