### PR TITLE
Change `false fail false` message

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -30,6 +30,7 @@ x.pass = function (msg) {
 };
 
 x.fail = function (msg) {
+	msg = msg || 'Test failed via t.fail()';
 	test(false, create(false, false, 'fail', msg, x.fail));
 };
 

--- a/test/api.js
+++ b/test/api.js
@@ -66,7 +66,7 @@ test('fail-fast mode', function (t) {
 			t.ok(api.options.failFast);
 			t.is(api.passCount, 1);
 			t.is(api.failCount, 1);
-			t.true(/false fail false/.test(api.errors[0].error.message));
+			t.true(/Test failed via t.fail()/.test(api.errors[0].error.message));
 		});
 });
 


### PR DESCRIPTION
This helps out with #315 by adding a default message to `x.fail()` so that the failing message is always helpful.

If there's a better message to use, let me know! It's a quick change.