### PR TITLE
Stop hiding source of syntax errors

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -25,6 +25,7 @@ var sourceMapCache = Object.create(null);
 
 var sourceMapSupport = require('source-map-support');
 sourceMapSupport.install({
+	handleUncaughtExceptions: false,
 	retrieveSourceMap: function (source) {
 		if (sourceMapCache[source]) {
 			return {
@@ -71,10 +72,6 @@ var options = {
 // check if test files required ava and show error, when they didn't
 exports.avaRequired = false;
 
-process.on('uncaughtException', function (exception) {
-	send('uncaughtException', {exception: serializeError(exception)});
-});
-
 // try to load an input source map for the test file, in case the file was
 // already compiled once by the user
 var inputSourceMap = sourceMapSupport.retrieveSourceMap(testPath);
@@ -89,6 +86,10 @@ var transpiled = babel.transformFileSync(testPath, options);
 sourceMapCache[testPath] = transpiled.map;
 requireFromString(transpiled.code, testPath, {
 	appendPaths: module.paths
+});
+
+process.on('uncaughtException', function (exception) {
+	send('uncaughtException', {exception: serializeError(exception)});
 });
 
 // if ava was not required, show an error

--- a/test/api.js
+++ b/test/api.js
@@ -241,7 +241,7 @@ test('testing nonexistent files rejects', function (t) {
 	api.run()
 		.catch(function (err) {
 			t.ok(err);
-			t.true(/Couldn't find any files to test/.test(err.message));
+			t.match(err.message, /Couldn't find any files to test/);
 		});
 });
 

--- a/test/api.js
+++ b/test/api.js
@@ -233,7 +233,7 @@ test('test file that immediately exits with 0 exit code ', function (t) {
 		});
 });
 
-test('testing nonexisting files rejects', function (t) {
+test('testing nonexistent files rejects', function (t) {
 	t.plan(2);
 
 	var api = new Api([path.join(__dirname, 'fixture/broken.js')]);

--- a/test/api.js
+++ b/test/api.js
@@ -107,22 +107,6 @@ test('change process.cwd() to a test\'s directory', function (t) {
 		});
 });
 
-test('babel require hook only applies to the test file', function (t) {
-	t.plan(3);
-
-	var api = new Api([path.join(__dirname, 'fixture/babel-hook.js')]);
-
-	api.on('error', function (data) {
-		t.is(data.name, 'SyntaxError');
-		t.true(/Unexpected token/.test(data.message));
-	});
-
-	api.run()
-		.catch(function (err) {
-			t.ok(err);
-		});
-});
-
 test('unhandled promises will throw an error', function (t) {
 	t.plan(3);
 
@@ -246,6 +230,18 @@ test('test file that immediately exits with 0 exit code ', function (t) {
 		.catch(function (err) {
 			t.ok(err);
 			t.true(/Test results were not received from/.test(err.message));
+		});
+});
+
+test('testing nonexisting files rejects', function (t) {
+	t.plan(2);
+
+	var api = new Api([path.join(__dirname, 'fixture/broken.js')]);
+
+	api.run()
+		.catch(function (err) {
+			t.ok(err);
+			t.true(/Couldn't find any files to test/.test(err.message));
 		});
 });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -89,7 +89,7 @@ test('babel require hook only applies to the test file', function (t) {
 
 	execCli('fixture/babel-hook.js', function (err, stdout, stderr) {
 		t.ok(err);
-		t.true(/Unexpected token/.test(stderr));
+		t.match(stderr, /Unexpected token/);
 		t.is(err.code, 1);
 		t.end();
 	});

--- a/test/cli.js
+++ b/test/cli.js
@@ -89,8 +89,8 @@ test('babel require hook only applies to the test file', function (t) {
 
 	execCli('fixture/babel-hook.js', function (err, stdout, stderr) {
 		t.ok(err);
-		t.match(stderr, /Unexpected token/);
 		t.is(err.code, 1);
+		t.match(stderr, /Unexpected token/);
 		t.end();
 	});
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -84,6 +84,27 @@ test('throwing a named function will report the to the console', function (t) {
 	});
 });
 
+test('babel require hook only applies to the test file', function (t) {
+	t.plan(3);
+
+	execCli('fixture/babel-hook.js', function (err, stdout, stderr) {
+		t.ok(err);
+		t.true(/Unexpected token/.test(stderr));
+		t.is(err.code, 1);
+		t.end();
+	});
+});
+
+test('rejects on error and streams output', function (t) {
+	t.plan(2);
+
+	execCli('fixture/broken.js', function (err, stdout, stderr) {
+		t.ok(err);
+		t.true(/Couldn't find any files to test/.test(stderr));
+		t.end();
+	});
+});
+
 test('throwing a anonymous function will report the function to the console', function (t) {
 	execCli('fixture/throw-anonymous-function.js', function (err, stdout, stderr) {
 		t.ok(err);

--- a/test/cli.js
+++ b/test/cli.js
@@ -95,16 +95,6 @@ test('babel require hook only applies to the test file', function (t) {
 	});
 });
 
-test('rejects on error and streams output', function (t) {
-	t.plan(2);
-
-	execCli('fixture/broken.js', function (err, stdout, stderr) {
-		t.ok(err);
-		t.true(/Couldn't find any files to test/.test(stderr));
-		t.end();
-	});
-});
-
 test('throwing a anonymous function will report the function to the console', function (t) {
 	execCli('fixture/throw-anonymous-function.js', function (err, stdout, stderr) {
 		t.ok(err);

--- a/test/fork.js
+++ b/test/fork.js
@@ -33,16 +33,14 @@ test('resolves promise with tests info', function (t) {
 		});
 });
 
-test('rejects on error and streams output', function (t) {
+test('rejects on nonexisting file', function (t) {
 	t.plan(2);
 
 	fork(fixture('broken.js'))
 		.run()
-		.on('uncaughtException', function (data) {
-			t.true(/no such file or directory/.test(data.exception.message));
-		})
-		.catch(function () {
-			t.pass();
+		.catch(function (err) {
+			t.true(/exited with a non-zero exit code: 1/.test(err.message));
+			t.ok(err);
 			t.end();
 		});
 });

--- a/test/fork.js
+++ b/test/fork.js
@@ -33,7 +33,7 @@ test('resolves promise with tests info', function (t) {
 		});
 });
 
-test('rejects on nonexisting file', function (t) {
+test('rejects on error and streams output', function (t) {
 	t.plan(2);
 
 	fork(fixture('broken.js'))

--- a/test/fork.js
+++ b/test/fork.js
@@ -39,7 +39,7 @@ test('rejects on error and streams output', function (t) {
 	fork(fixture('broken.js'))
 		.run()
 		.catch(function (err) {
-			t.true(/exited with a non-zero exit code: 1/.test(err.message));
+			t.match(err.message, /exited with a non-zero exit code: \d/);
 			t.ok(err);
 			t.end();
 		});

--- a/test/fork.js
+++ b/test/fork.js
@@ -39,8 +39,8 @@ test('rejects on error and streams output', function (t) {
 	fork(fixture('broken.js'))
 		.run()
 		.catch(function (err) {
-			t.match(err.message, /exited with a non-zero exit code: \d/);
 			t.ok(err);
+			t.match(err.message, /exited with a non-zero exit code: \d/);
 			t.end();
 		});
 });


### PR DESCRIPTION
This helps out with #308. It does the following things:

* Make the changes noted [here](https://github.com/jamestalmage/ava/commit/b1986249b6b59efba05413be3a7b746c4f2bc27d)
* Move babel hook test to CLI (needed after making change above)
* Add an API test for nonexistent files

However, there's one issue. The `fork.js` test that calls a nonexistent file ("rejects on error and streams output") doesn't seem to get a "file does not exist error" (it just gets "error code 1 returned") and worse, a stack of it shows up in the [test results](http://i.imgur.com/5Pe6Ifq.png). The testing continues fine though, but I am not sure how to contain it or test it.

Originally the test had an `.on('uncaughtException')` clause but after making the `babel.js` changes, it is not called at all so I removed it.

Any suggestions and help is appreciated!