### PR TITLE
use `empower-core` for better assertion tracking and performance

### DIFF
--- a/api.js
+++ b/api.js
@@ -70,12 +70,21 @@ Api.prototype._handleStats = function (stats) {
 	this.testCount += stats.testCount;
 };
 
+var formatter = require('./lib/enhance-assert').formatter();
+
 Api.prototype._handleTest = function (test) {
 	test.title = this._prefixTitle(test.file) + test.title;
 
 	var isError = test.error.message;
 
 	if (isError) {
+		if (test.error.powerAssertContext) {
+			var message = formatter(test.error.powerAssertContext);
+			if (test.error.originalMessage) {
+				message = test.error.originalMessage + ' ' + message;
+			}
+			test.error.message = message;
+		}
 		this.errors.push(test);
 	} else {
 		test.error = null;

--- a/api.js
+++ b/api.js
@@ -9,6 +9,7 @@ var figures = require('figures');
 var globby = require('globby');
 var chalk = require('chalk');
 var fork = require('./lib/fork');
+var formatter = require('./lib/enhance-assert').formatter();
 
 function Api(files, options) {
 	if (!(this instanceof Api)) {
@@ -69,8 +70,6 @@ Api.prototype._handleExceptions = function (data) {
 Api.prototype._handleStats = function (stats) {
 	this.testCount += stats.testCount;
 };
-
-var formatter = require('./lib/enhance-assert').formatter();
 
 Api.prototype._handleTest = function (test) {
 	test.title = this._prefixTitle(test.file) + test.title;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -120,5 +120,3 @@ x.regexTest = function (regex, contents, msg) {
 x.ifError = x.error = function (err, msg) {
 	test(!err, create(err, 'Error', '!==', msg, x.ifError));
 };
-
-require('./enhance-assert')(x);

--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -22,7 +22,7 @@ module.exports.NON_ENHANCED_PATTERNS = [
 ];
 
 function enhanceAssert(opts) {
-	var empower = require('@jamestalmage/empower-core');
+	var empower = require('empower-core');
 	var enhanced = empower(
 		opts.assert,
 		{

--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -1,4 +1,5 @@
 module.exports = enhanceAssert;
+module.exports.formatter = formatter;
 
 module.exports.PATTERNS = [
 	't.ok(value, [message])',
@@ -12,23 +13,40 @@ module.exports.PATTERNS = [
 	't.regexTest(regex, contents, [message])'
 ];
 
-function enhanceAssert(assert) {
-	var empower = require('empower');
+module.exports.NON_ENHANCED_PATTERNS = [
+	't.pass([message])',
+	't.fail([message])',
+	't.throws(fn, [message])',
+	't.doesNotThrow(fn, [message])',
+	't.ifError(error, [message])'
+];
+
+function enhanceAssert(opts) {
+	var empower = require('@jamestalmage/empower-core');
+	var enhanced = empower(
+		opts.assert,
+		{
+			destructive: false,
+			onError: opts.onError,
+			onSuccess: opts.onSuccess,
+			patterns: module.exports.PATTERNS,
+			additionalMethods: module.exports.NON_ENHANCED_PATTERNS
+		}
+	);
+
+	enhanced.AssertionError = opts.assert.AssertionError;
+
+	return enhanced;
+}
+
+function formatter() {
 	var powerAssertFormatter = require('power-assert-formatter');
 	var powerAssertRenderers = require('power-assert-renderers');
 
-	empower(assert,
-		powerAssertFormatter({
-			renderers: [
-				powerAssertRenderers.AssertionRenderer,
-				powerAssertRenderers.SuccinctRenderer
-			]
-		}),
-		{
-			destructive: true,
-			modifyMessageOnRethrow: true,
-			saveContextOnRethrow: false,
-			patterns: module.exports.PATTERNS
-		}
-	);
+	return powerAssertFormatter({
+		renderers: [
+			powerAssertRenderers.AssertionRenderer,
+			powerAssertRenderers.SuccinctRenderer
+		]
+	});
 }

--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -30,7 +30,7 @@ function enhanceAssert(opts) {
 			onError: opts.onError,
 			onSuccess: opts.onSuccess,
 			patterns: module.exports.PATTERNS,
-			additionalMethods: module.exports.NON_ENHANCED_PATTERNS
+			wrapOnlyPatterns: module.exports.NON_ENHANCED_PATTERNS
 		}
 	);
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -8,6 +8,7 @@ var observableToPromise = require('observable-to-promise');
 var isPromise = require('is-promise');
 var isObservable = require('is-observable');
 var assert = require('./assert');
+var enhanceAssert = require('./enhance-assert');
 var globals = require('./globals');
 
 function Test(title, fn) {
@@ -60,11 +61,6 @@ Test.prototype._setAssertError = function (err) {
 
 	this.assertError = err;
 };
-
-// Workaround for power-assert
-// `t` must be capturable for decorated assert output
-Test.prototype._capt = assert._capt;
-Test.prototype._expr = assert._expr;
 
 Test.prototype.plan = function (count) {
 	if (typeof count !== 'number') {
@@ -208,9 +204,7 @@ Test.prototype._publicApi = function () {
 	[
 		'assertCount',
 		'title',
-		'end',
-		'_capt',
-		'_expr'
+		'end'
 	]
 		.forEach(function (name) {
 			Object.defineProperty(api, name, {
@@ -239,31 +233,45 @@ Test.prototype._publicApi = function () {
 		self._assert();
 	}
 
+	function onAssertionEvent(event) {
+		if (event.type === 'error') {
+			event.error.powerAssertContext = event.powerAssertContext;
+			event.error.originalMessage = event.originalMessage;
+			self._setAssertError(event.error);
+			self._assert();
+			return null;
+		}
+
+		var fn = observableToPromise(event.returnValue);
+
+		if (isPromise(fn)) {
+			return Promise.resolve(fn)
+				.catch(function (err) {
+					self._setAssertError(err);
+				})
+				.finally(function () {
+					self._assert();
+				});
+		}
+
+		self._assert();
+		return null;
+	}
+
+	var enhanced = enhanceAssert({
+		assert: assert,
+		onSuccess: onAssertionEvent,
+		onError: onAssertionEvent
+	});
+
 	// Patched assert methods: increase assert count and store errors.
 	Object.keys(assert).forEach(function (el) {
 		api.skip[el] = skipFn;
-		api[el] = function () {
-			try {
-				var fn = assert[el].apply(assert, arguments);
-
-				fn = observableToPromise(fn);
-
-				if (isPromise(fn)) {
-					return Promise.resolve(fn)
-						.catch(function (err) {
-							self._setAssertError(err);
-						})
-						.finally(function () {
-							self._assert();
-						});
-				}
-			} catch (err) {
-				self._setAssertError(err);
-			}
-
-			self._assert();
-		};
+		api[el] = enhanced[el].bind(enhanced);
 	});
+
+	api._capt = enhanced._capt.bind(enhanced);
+	api._expr = enhanced._expr.bind(enhanced);
 
 	return api;
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -234,7 +234,7 @@ Test.prototype._publicApi = function () {
 	}
 
 	function onAssertionEvent(event) {
-		if (event.type === 'error') {
+		if (event.assertionThrew) {
 			event.error.powerAssertContext = event.powerAssertContext;
 			event.error.originalMessage = event.originalMessage;
 			self._setAssertError(event.error);
@@ -247,6 +247,7 @@ Test.prototype._publicApi = function () {
 		if (isPromise(fn)) {
 			return Promise.resolve(fn)
 				.catch(function (err) {
+					err.originalMessage = event.originalMessage;
 					self._setAssertError(err);
 				})
 				.finally(function () {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "observables"
   ],
   "dependencies": {
+    "@jamestalmage/empower-core": "^0.1.1",
     "arr-flatten": "^1.0.1",
     "arrify": "^1.0.0",
     "ava-init": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "observables"
   ],
   "dependencies": {
-    "@jamestalmage/empower-core": "^0.1.1",
     "arr-flatten": "^1.0.1",
     "arrify": "^1.0.0",
     "ava-init": "^0.1.0",
@@ -91,6 +90,7 @@
     "debug": "^2.2.0",
     "deeper": "^2.1.0",
     "empower": "^1.1.0",
+    "empower-core": "^0.2.0",
     "figures": "^1.4.0",
     "fn-name": "^2.0.0",
     "globby": "^4.0.0",

--- a/test/api.js
+++ b/test/api.js
@@ -270,3 +270,24 @@ test('Node.js-style --require CLI argument', function (t) {
 			t.is(api.passCount, 1);
 		});
 });
+
+test('power-assert support', function (t) {
+	t.plan(3);
+
+	var api = new Api([path.join(__dirname, 'fixture/power-assert.js')]);
+
+	api.run()
+		.then(function () {
+			t.ok(api.errors[0].error.powerAssertContext);
+
+			t.match(
+				api.errors[0].error.message,
+				/t\.ok\(a === 'bar'\)\s*\n\s+\|\s*\n\s+"foo"/m
+			);
+
+			t.match(
+				api.errors[1].error.message,
+				/with message\s+t\.ok\(a === 'foo', 'with message'\)\s*\n\s+\|\s*\n\s+"bar"/m
+			);
+		});
+});

--- a/test/fixture/power-assert.js
+++ b/test/fixture/power-assert.js
@@ -1,7 +1,13 @@
 import test from '../../';
 
-test(t => {
+test.serial(t => {
 	const a = 'foo';
 
 	t.ok(a === 'bar');
+});
+
+test.serial(t => {
+	const a = 'bar';
+
+	t.ok(a === 'foo', 'with message');
 });


### PR DESCRIPTION
This switches us to the ([much](https://github.com/twada/empower-assert/pull/2#issuecomment-159793918)) lighter weight `empower-core`.

`empower-core` does not render the pretty assertion graphs in the forked processes. So we need to use `empower-formatter`s in the main process to finalize the enhancement. The browserified build of `empower-core` is [90% smaller than empower](https://github.com/twada/empower-assert/pull/2#issuecomment-159793918). However, we won't see much of that benefit until we move Babel transpiling to the main process as well (since the `power-assert` transform has a largely overlapping dependency graph with `empower`).

The immediate benefit is that this provides a very easy way to track assertions and methods which will be beneficial to TAP support.

It currently relies on the initial changes made in https://github.com/twada/empower-core/pull/2, but it will be trivial to update once that is merged and deployed. Currently it points to a dependency in the `@jamestalmage` namespace so as not to reintroduce a git dependency which seems to give some people problems. 