### PR TITLE
Add more logger tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.4",
+    "hook-std": "^0.1.0",
     "signal-exit": "^2.1.2",
     "sinon": "^1.17.2",
     "source-map-fixtures": "^0.3.0",

--- a/test/logger.js
+++ b/test/logger.js
@@ -20,7 +20,7 @@ test('beautify stack - removes uninteresting lines', function (t) {
 test('logger.write', function (t) {
 	t.plan(1);
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), 'Test');
@@ -33,7 +33,7 @@ test('logger.write', function (t) {
 test('logger.writelpad', function (t) {
 	t.plan(1);
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), '  Test');
@@ -46,7 +46,7 @@ test('logger.writelpad', function (t) {
 test('logger.success', function (t) {
 	t.plan(1);
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), '  ' + figures.tick + ' Test');
@@ -59,7 +59,7 @@ test('logger.success', function (t) {
 test('logger.error', function (t) {
 	t.plan(1);
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), '  ' + figures.cross + ' Test');
@@ -77,7 +77,7 @@ test('logger.test with passing test and duration less than threshold', function 
 		duration: 90
 	};
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), '  ' + figures.tick + ' Passed');
@@ -95,7 +95,7 @@ test('logger.test with passing test and duration greater than threshold', functi
 		duration: 150
 	};
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), '  ' + figures.tick + ' Passed (150ms)');
@@ -115,7 +115,7 @@ test('logger.test with failing test', function (t) {
 		}
 	};
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), '  ' + figures.cross + ' Failed Assertion failed');
@@ -133,7 +133,7 @@ test('logger.test with skipped test', function (t) {
 		skipped: true
 	};
 
-	var unhook = hookStd.stderr({silent: true}, output => {
+	var unhook = hookStd.stderr({silent: true}, function (output) {
 		unhook();
 
 		t.is(output.toString(), '  ' + figures.tick + ' Skipped');

--- a/test/logger.js
+++ b/test/logger.js
@@ -178,7 +178,7 @@ test('logger.report', function (t) {
 });
 
 test('logger.unhandledError with exception with stack', function (t) {
-	t.plan(2);
+	t.plan(3);
 
 	var lines = [];
 
@@ -189,7 +189,8 @@ test('logger.unhandledError with exception with stack', function (t) {
 	logger.unhandledError('exception', 'test.js', new Error('Unexpected token'));
 
 	t.is(lines[0], 'Uncaught Exception: test.js\n');
-	t.match(lines[1], /Error: Unexpected token\n\s+at Test.test/);
+	t.match(lines[1], /Error: Unexpected token\n/);
+	t.match(lines[1], /at Test.test/);
 });
 
 test('logger.unhandledError with exception without stack', function (t) {
@@ -211,7 +212,7 @@ test('logger.unhandledError with exception without stack', function (t) {
 });
 
 test('logger.unhandledError rejection with stack', function (t) {
-	t.plan(2);
+	t.plan(3);
 
 	var lines = [];
 
@@ -222,7 +223,8 @@ test('logger.unhandledError rejection with stack', function (t) {
 	logger.unhandledError('rejection', 'test.js', new Error('I have been rejected'));
 
 	t.is(lines[0], 'Unhandled Rejection: test.js\n');
-	t.match(lines[1], /Error: I have been rejected\s+at Test.test/);
+	t.match(lines[1], /Error: I have been rejected\n/);
+	t.match(lines[1], /at Test.test/);
 });
 
 test('logger.unhandledError rejection without stack', function (t) {

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,6 +1,8 @@
 'use strict';
 var test = require('tap').test;
 var logger = require('../lib/logger');
+var figures = require('figures');
+var hookStd = require('hook-std');
 
 test('beautify stack - removes uninteresting lines', function (t) {
 	try {
@@ -15,10 +17,243 @@ test('beautify stack - removes uninteresting lines', function (t) {
 	}
 });
 
+test('logger.write', function (t) {
+	t.plan(1);
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), 'Test');
+		t.end();
+	});
+
+	logger.write('Test');
+});
+
+test('logger.writelpad', function (t) {
+	t.plan(1);
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), '  Test');
+		t.end();
+	});
+
+	logger.writelpad('Test');
+});
+
+test('logger.success', function (t) {
+	t.plan(1);
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), '  ' + figures.tick + ' Test');
+		t.end();
+	});
+
+	logger.success('Test');
+});
+
+test('logger.error', function (t) {
+	t.plan(1);
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), '  ' + figures.cross + ' Test');
+		t.end();
+	});
+
+	logger.error('Test');
+});
+
+test('logger.test with passing test and duration less than threshold', function (t) {
+	t.plan(1);
+
+	var passingTest = {
+		title: 'Passed',
+		duration: 90
+	};
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), '  ' + figures.tick + ' Passed');
+		t.end();
+	});
+
+	logger.test(passingTest);
+});
+
+test('logger.test with passing test and duration greater than threshold', function (t) {
+	t.plan(1);
+
+	var passingTest = {
+		title: 'Passed',
+		duration: 150
+	};
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), '  ' + figures.tick + ' Passed (150ms)');
+		t.end();
+	});
+
+	logger.test(passingTest);
+});
+
+test('logger.test with failing test', function (t) {
+	t.plan(1);
+
+	var passingTest = {
+		title: 'Failed',
+		err: {
+			message: 'Assertion failed'
+		}
+	};
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), '  ' + figures.cross + ' Failed Assertion failed');
+		t.end();
+	});
+
+	logger.test(passingTest);
+});
+
+test('logger.test with skipped test', function (t) {
+	t.plan(1);
+
+	var skippedTest = {
+		title: 'Skipped',
+		skipped: true
+	};
+
+	var unhook = hookStd.stderr({silent: true}, output => {
+		unhook();
+
+		t.is(output.toString(), '  ' + figures.tick + ' Skipped');
+		t.end();
+	});
+
+	logger.test(skippedTest);
+});
+
+test('logger.errors', function (t) {
+	t.plan(1);
+
+	var lines = [];
+	var failedTest = {
+		title: 'Failed',
+		error: {
+			stack: 'Unexpected token'
+		}
+	};
+
+	hookStd.stderr({silent: true}, function (output) {
+		onLine(lines, output);
+	});
+
+	logger.errors([failedTest]);
+
+	t.is(lines.join(''), '1. Failed\nUnexpected token\n');
+});
+
+test('logger.report', function (t) {
+	t.plan(1);
+
+	var lines = [];
+
+	hookStd.stderr({silent: true}, function (output) {
+		onLine(lines, output);
+	});
+
+	logger.report(1, 2, 1, 2);
+
+	t.is(lines.join(''), '2 tests failed\n1 unhandled rejection\n2 uncaught exceptions\n');
+});
+
+test('logger.unhandledError with exception with stack', function (t) {
+	t.plan(2);
+
+	var lines = [];
+
+	hookStd.stderr({silent: true}, function (output) {
+		onLine(lines, output);
+	});
+
+	logger.unhandledError('exception', 'test.js', new Error('Unexpected token'));
+
+	t.is(lines[0], 'Uncaught Exception: test.js\n');
+	t.match(lines[1], /Error: Unexpected token\n\s+at Test.test/);
+});
+
+test('logger.unhandledError with exception without stack', function (t) {
+	t.plan(2);
+
+	var lines = [];
+	var error = {
+		message: 'Unexpected token'
+	};
+
+	hookStd.stderr({silent: true}, function (output) {
+		onLine(lines, output);
+	});
+
+	logger.unhandledError('exception', 'test.js', error);
+
+	t.is(lines[0], 'Uncaught Exception: test.js\n');
+	t.is(lines[1], '{"message":"Unexpected token"}\n');
+});
+
+test('logger.unhandledError rejection with stack', function (t) {
+	t.plan(2);
+
+	var lines = [];
+
+	hookStd.stderr({silent: true}, function (output) {
+		onLine(lines, output);
+	});
+
+	logger.unhandledError('rejection', 'test.js', new Error('I have been rejected'));
+
+	t.is(lines[0], 'Unhandled Rejection: test.js\n');
+	t.match(lines[1], /Error: I have been rejected\s+at Test.test/);
+});
+
+test('logger.unhandledError rejection without stack', function (t) {
+	t.plan(2);
+
+	var lines = [];
+	var error = {
+		message: 'I have been rejected'
+	};
+
+	hookStd.stderr({silent: true}, function (output) {
+		onLine(lines, output);
+	});
+
+	logger.unhandledError('rejection', 'test.js', error);
+
+	t.is(lines[0], 'Unhandled Rejection: test.js\n');
+	t.is(lines[1], '{"message":"I have been rejected"}\n');
+});
+
 function fooFunc() {
 	barFunc();
 }
 
 function barFunc() {
 	throw new Error();
+}
+
+function onLine(lines, line) {
+	var trimmed = line.trim();
+	if (trimmed.length) {
+		lines.push(line.trim() + '\n');
+	}
 }


### PR DESCRIPTION
This helps out with https://github.com/sindresorhus/ava/issues/161 by adding more tests to the `lib/logger.js` file, which brings the coverage up a bit.

This is WIP because I am waiting on [this](https://github.com/sindresorhus/hook-std/issues/2) to get resolved as such a feature would simplify the tests, and of course because you guys might have some suggestions (especially when testing the error stacks).