### PR TITLE
remove `empower` from dependencies since it is replaced with `empower…

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "core-assert": "^0.1.0",
     "debug": "^2.2.0",
     "deeper": "^2.1.0",
-    "empower": "^1.1.0",
     "empower-core": "^0.2.0",
     "figures": "^1.4.0",
     "fn-name": "^2.0.0",


### PR DESCRIPTION
This PR removes `empower` from dependencies since it is replaced with new `empower-core`.

I gave LGTM to #330 but I missed this point. So sorry..
