### PR TITLE
Move test title prefixes test to API tests

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -64,7 +64,8 @@ test('test title prefixes', function (t) {
 		});
 
 	api.on('test', function (a) {
-		index = expected.indexOf(a.title.replace('test › fixture › ', ''));
+		var unnecessaryString = 'test' + separator + 'fixture' + separator;
+		index = expected.indexOf(a.title.replace(unnecessaryString, ''));
 
 		t.true(index >= 0);
 

--- a/test/api.js
+++ b/test/api.js
@@ -1,5 +1,6 @@
 'use strict';
 var path = require('path');
+var figures = require('figures');
 var test = require('tap').test;
 var Api = require('../api');
 
@@ -39,47 +40,37 @@ test('async/await support', function (t) {
 test('test title prefixes', function (t) {
 	t.plan(5);
 
+	var separator = ' ' + figures.pointerSmall + ' ';
 	var files = [
 		path.join(__dirname, 'fixture/async-await.js'),
 		path.join(__dirname, 'fixture/es2015.js'),
 		path.join(__dirname, 'fixture/generators.js')
 	];
 	var expected = [
-		'async-await async function',
-		'async-await arrow async function',
-		'es2015 [anonymous]',
-		'generators generator function'
+		['async-await', 'async function'].join(separator),
+		['async-await', 'arrow async function'].join(separator),
+		['es2015', '[anonymous]'].join(separator),
+		['generators', 'generator function'].join(separator)
 	];
 	var index;
-	var file;
 
 	var api = new Api(files);
 
 	api.run()
 		.then(function () {
-			api.tests.forEach(function (test, i) {
-				// the first two tests are from async-await.js
-				if (i === 0 || i === 1) {
-					file = api.files[0];
-				} else {
-					file = files[i - 1];
-				}
-
-				// path/to/file.js -> file
-				file = file.replace(/^.*[\\\/]/, '').slice(0, -3);
-
-				index = expected.indexOf(file + ' ' + test.title);
-
-				t.true(index >= 0);
-
-				// remove line from expected output
-				expected.splice(index, 1);
-			});
-
 			// if all lines were removed from expected output
 			// actual output matches expected output
 			t.is(expected.length, 0);
 		});
+
+	api.on('test', function (a) {
+		index = expected.indexOf(a.title.replace('test › fixture › ', ''));
+
+		t.true(index >= 0);
+
+		// remove line from expected output
+		expected.splice(index, 1);
+	});
 });
 
 test('display filename prefixes for failed test stack traces', function (t) {

--- a/test/api.js
+++ b/test/api.js
@@ -45,19 +45,30 @@ test('test title prefixes', function (t) {
 		path.join(__dirname, 'fixture/generators.js')
 	];
 	var expected = [
-		'async function',
-		'arrow async function',
-		'[anonymous]',
-		'generator function'
+		'async-await async function',
+		'async-await arrow async function',
+		'es2015 [anonymous]',
+		'generators generator function'
 	];
 	var index;
+	var file;
 
 	var api = new Api(files);
 
 	api.run()
 		.then(function () {
-			api.tests.forEach(function (test) {
-				index = expected.indexOf(test.title);
+			api.tests.forEach(function (test, i) {
+				// the first two tests are from async-await.js
+				if (i === 0 || i === 1) {
+					file = api.files[0];
+				} else {
+					file = files[i - 1];
+				}
+
+				// path/to/file.js -> file
+				file = file.replace(/^.*[\\\/]/, '').slice(0, -3);
+
+				index = expected.indexOf(file + ' ' + test.title);
 
 				t.true(index >= 0);
 

--- a/test/api.js
+++ b/test/api.js
@@ -36,6 +36,41 @@ test('async/await support', function (t) {
 		});
 });
 
+test('test title prefixes', function (t) {
+	t.plan(5);
+
+	var files = [
+		path.join(__dirname, 'fixture/async-await.js'),
+		path.join(__dirname, 'fixture/es2015.js'),
+		path.join(__dirname, 'fixture/generators.js')
+	];
+	var expected = [
+		'async function',
+		'arrow async function',
+		'[anonymous]',
+		'generator function'
+	];
+	var index;
+
+	var api = new Api(files);
+
+	api.run()
+		.then(function () {
+			api.tests.forEach(function (test) {
+				index = expected.indexOf(test.title);
+
+				t.true(index >= 0);
+
+				// remove line from expected output
+				expected.splice(index, 1);
+			});
+
+			// if all lines were removed from expected output
+			// actual output matches expected output
+			t.is(expected.length, 0);
+		});
+});
+
 test('display filename prefixes for failed test stack traces', function (t) {
 	t.plan(3);
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,6 +1,5 @@
 'use strict';
 var childProcess = require('child_process');
-var figures = require('figures');
 var test = require('tap').test;
 
 function execCli(args, cb) {
@@ -19,50 +18,6 @@ function execCli(args, cb) {
 		env: env
 	}, cb);
 }
-
-test('display test title prefixes', function (t) {
-	t.plan(6);
-
-	execCli([
-		'fixture/async-await.js',
-		'fixture/es2015.js',
-		'fixture/generators.js'
-	], function (err, stdout, stderr) {
-		t.ifError(err);
-
-		// remove everything except test list
-		var output = stderr
-			.replace(/[0-9] tests passed/, '')
-			.replace(new RegExp(figures.tick, 'gm'), '')
-			.replace(/^\s+/gm, '')
-			.trim();
-
-		var separator = ' ' + figures.pointerSmall + ' ';
-
-		// expected output
-		var tests = [
-			['async-await', 'async function'].join(separator),
-			['async-await', 'arrow async function'].join(separator),
-			['generators', 'generator function'].join(separator),
-			['es2015', '[anonymous]'].join(separator)
-		];
-
-		// check if each line in actual output
-		// exists in expected output
-		output.split('\n').forEach(function (line) {
-			var index = tests.indexOf(line);
-
-			t.true(index >= 0);
-
-			// remove line from expected output
-			tests.splice(index, 1);
-		});
-
-		// if all lines were removed from expected output
-		// actual output matches expected output
-		t.is(tests.length, 0);
-	});
-});
 
 test('don\'t display test title if there is only one anonymous test', function (t) {
 	t.plan(2);


### PR DESCRIPTION
This (hopefully) helps out with https://github.com/sindresorhus/ava/issues/335 by moving the test title prefixes test from the CLI tests to the API tests.