### PR TITLE
[Exploratory] Capture good assertion messages.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -233,7 +233,24 @@ Test.prototype._publicApi = function () {
 		self._assert();
 	}
 
+	function stringify(arg) {
+		return JSON.stringify(arg);
+	}
+
 	function onAssertionEvent(event) {
+		var message;
+
+		if (event.originalMessage) {
+			message = event.originalMessage;
+		} else if (event.powerAssertContext) {
+			message = event.powerAssertContext.source.content;
+		} else {
+			message = 't.' + event.methodName + '(' + event.args.slice(0, event.numArgs).map(stringify).join(', ') + ')';
+		}
+		// TODO(jamestalmage): This will not work great for enhanced = false, since args could be complex.
+
+		console.log(message);
+
 		if (event.assertionThrew) {
 			event.error.powerAssertContext = event.powerAssertContext;
 			event.error.originalMessage = event.originalMessage;
@@ -259,16 +276,25 @@ Test.prototype._publicApi = function () {
 		return null;
 	}
 
+	function identitiy(event) {
+		return event;
+	}
+
 	var enhanced = enhanceAssert({
 		assert: assert,
-		onSuccess: onAssertionEvent,
-		onError: onAssertionEvent
+		onSuccess: identitiy,
+		onError: identitiy
 	});
 
 	// Patched assert methods: increase assert count and store errors.
 	Object.keys(assert).forEach(function (el) {
 		api.skip[el] = skipFn;
-		api[el] = enhanced[el].bind(enhanced);
+		api[el] = function () {
+			var event = enhanced[el].apply(enhanced, arguments);
+			event.methodName = el;
+			event.numArgs = arguments.length;
+			return onAssertionEvent(event);
+		};
 	});
 
 	api._capt = enhanced._capt.bind(enhanced);


### PR DESCRIPTION
This just is a quick spike exploring the best way to capture assertion messages.

The only place this does not work great is for `wrapOnlyPatterns`, since you can end up with a situation where `powerAssertContext` does not exist even though the `args` has elements that do not `stringify` well.

@twada - What do you think about moving this logic into `empower-core`? Auto populating `event.computedMessage` or similar?

Maybe we can offer a standard way to map `wrapOnlyPatterns` to messages?

```js
{
  wrapOnlyPatterns: {
    't.throws(fn, [message])': {
       defaultMessage: 'should throw'
    },
    't.doesNotThrow(fn, [message]': {
        defaultMessage: 'should not throw'
    }
  }
}

// ...

function onAssert(event) {
  var message;
  if (event.enhanced === false) {
     message = event.defaultMessage
  }
}
```

