### PR TITLE
Fix fail-fast mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,16 +37,18 @@ function test(props) {
 		return;
 	}
 
+	var hasError = typeof props.error !== 'undefined';
+
 	// don't display anything if it's a passed hook
-	if (!props.error && props.type !== 'test') {
+	if (!hasError && props.type !== 'test') {
 		return;
 	}
 
-	props.error = props.error ? serializeError(props.error) : {};
+	props.error = hasError ? serializeError(props.error) : {};
 
 	send('test', props);
 
-	if (props.error && opts.failFast) {
+	if (hasError && opts.failFast) {
 		isFailed = true;
 		exit();
 	}

--- a/test/api.js
+++ b/test/api.js
@@ -93,16 +93,32 @@ test('display filename prefixes for failed test stack traces', function (t) {
 });
 
 test('fail-fast mode', function (t) {
-	t.plan(4);
+	t.plan(5);
 
 	var api = new Api([path.join(__dirname, 'fixture/fail-fast.js')], {
 		failFast: true
 	});
 
+	var tests = [];
+
+	api.on('test', function (test) {
+		tests.push({
+			ok: !test.error,
+			title: test.title
+		});
+	});
+
 	api.run()
 		.then(function () {
 			t.ok(api.options.failFast);
-			t.is(api.passCount, 1);
+			t.same(tests, [{
+				ok: true,
+				title: 'first pass'
+			}, {
+				ok: false,
+				title: 'second fail'
+			}]);
+			t.is(api.passCount, 2);
 			t.is(api.failCount, 1);
 			t.match(api.errors[0].error.message, /Test failed via t.fail()/);
 		});

--- a/test/fixture/fail-fast.js
+++ b/test/fixture/fail-fast.js
@@ -1,9 +1,13 @@
 import test from '../../';
 
-test(t => {
+test('first pass', t => {
+	t.pass();
+});
+
+test('second fail', t => {
 	t.fail();
 });
 
-test(t => {
+test('third pass', t => {
 	t.pass();
 });


### PR DESCRIPTION
This PR fixes fail-fast mode. It was broken because of:

```js
props.error = props.error ? serializeError(props.error) : {};
// and
if (props.error && opts.failFast) {
```

Because of that, the `if` condition is always true and fail-fast mode was not working properly.