### PR TITLE
Add CLI test for logging failed tests

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -59,3 +59,10 @@ test('throwing a anonymous function will report the function to the console', fu
 		t.end();
 	});
 });
+
+test('log failed tests', function (t) {
+	execCli('fixture/one-pass-one-fail.js', function (err, stdout, stderr) {
+		t.match(stderr, /AssertionError: false == true/);
+		t.end();
+	});
+});


### PR DESCRIPTION
This helps with https://github.com/sindresorhus/ava/issues/161 by adding one test to the CLI tests that makes sure failed tests are logged.

I'm actually not sure if this test is needed—I just saw that it was an "uncovered" line on Coveralls and indeed the coverage went up after writing it.