### PR TITLE
Require babel plugins directly. Fixes #350.

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -52,8 +52,8 @@ var powerAssert = createEspowerPlugin(babel, {
 
 // if generators are not supported, use regenerator
 var options = {
-	presets: ['stage-2', 'es2015'],
-	plugins: [powerAssert, 'transform-runtime'],
+	presets: [require('babel-preset-stage-2'), require('babel-preset-es2015')],
+	plugins: [powerAssert, require('babel-plugin-transform-runtime')],
 	sourceMaps: true
 };
 


### PR DESCRIPTION
Also seems to make Babel 5 support "just work".