### PR TITLE
Show full stack trace for non-assert errors

### DIFF
--- a/api.js
+++ b/api.js
@@ -84,8 +84,14 @@ Api.prototype._handleTest = function (test) {
 			if (test.error.originalMessage) {
 				message = test.error.originalMessage + ' ' + message;
 			}
+
 			test.error.message = message;
 		}
+
+		if (test.error.name !== 'AssertionError') {
+			test.error.message = 'failed with "' + test.error.message + '"';
+		}
+
 		this.errors.push(test);
 	} else {
 		test.error = null;

--- a/lib/test.js
+++ b/lib/test.js
@@ -118,12 +118,7 @@ Test.prototype.run = function () {
 				self.exit();
 			})
 			.catch(function (err) {
-				self._setAssertError(new assert.AssertionError({
-					actual: err,
-					message: 'Promise rejected → ' + err,
-					operator: 'promise'
-				}));
-
+				self._setAssertError(err);
 				self.exit();
 			});
 	} else if (!this.metadata.callback) {

--- a/test/promise.js
+++ b/test/promise.js
@@ -245,7 +245,8 @@ test('reject', function (t) {
 		});
 	}).run().catch(function (err) {
 		t.ok(err);
-		t.is(err.name, 'AssertionError');
+		t.is(err.name, 'Error');
+		t.is(err.message, 'unicorn');
 		t.end();
 	});
 });


### PR DESCRIPTION
This PR fixes #271. Now AVA shows full stack trace for non-assertion errors. Before, it wrapped them in `assert.AssertionError`, which swallowed the original stack.