### PR TITLE
Ignore files in fixtures and helpers directories

### DIFF
--- a/api.js
+++ b/api.js
@@ -195,6 +195,8 @@ function handlePaths(files) {
 	}
 
 	files.push('!**/node_modules/**');
+	files.push('!**/fixtures/**');
+	files.push('!**/helpers/**');
 
 	// convert pinkie-promise to Bluebird promise
 	files = Promise.resolve(globby(files));

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ $ ava --help
   test.js test-*.js test/*.js
 ```
 
-Files starting with `_` are ignored. This can be useful for having helpers in the same directory as your test files.
+Files in directories named `fixtures` and `helpers` are ignored, as well as files starting with `_`. This can be useful for having helpers in the same directory as your test files.
 
 *WARNING: NON-STANDARD BEHAVIOR:* The AVA CLI will always try to find and use your projects local install of AVA. This is true even when you run the global `ava` command. This non-standard behavior solves an important [issue](https://github.com/sindresorhus/ava/issues/157), and should have no impact on everyday use.
 

--- a/test/api.js
+++ b/test/api.js
@@ -302,7 +302,31 @@ test('testing nonexistent files rejects', function (t) {
 test('test file in node_modules is ignored', function (t) {
 	t.plan(2);
 
-	var api = new Api([path.join(__dirname, 'fixture/node_modules/test.js')]);
+	var api = new Api([path.join(__dirname, 'fixture/ignored-dirs/node_modules/test.js')]);
+
+	api.run()
+		.catch(function (err) {
+			t.ok(err);
+			t.match(err.message, /Couldn't find any files to test/);
+		});
+});
+
+test('test file in fixtures is ignored', function (t) {
+	t.plan(2);
+
+	var api = new Api([path.join(__dirname, 'fixture/ignored-dirs/fixtures/test.js')]);
+
+	api.run()
+		.catch(function (err) {
+			t.ok(err);
+			t.match(err.message, /Couldn't find any files to test/);
+		});
+});
+
+test('test file in helpers is ignored', function (t) {
+	t.plan(2);
+
+	var api = new Api([path.join(__dirname, 'fixture/ignored-dirs/helpers/test.js')]);
 
 	api.run()
 		.catch(function (err) {

--- a/test/fixture/ignored-dirs/fixtures/test.js
+++ b/test/fixture/ignored-dirs/fixtures/test.js
@@ -1,4 +1,4 @@
-import test from '../../';
+import test from '../../../../';
 
 test(t => {
 	t.pass();

--- a/test/fixture/ignored-dirs/helpers/test.js
+++ b/test/fixture/ignored-dirs/helpers/test.js
@@ -1,0 +1,6 @@
+import test from '../../../../';
+
+test(t => {
+	t.pass();
+	t.end();
+});


### PR DESCRIPTION
This fixes https://github.com/sindresorhus/ava/issues/355 by adding the required code to ignore files in directories named `fixtures` and/or `helpers` as well as documentation and tests.
