### PR TITLE
Add mini reporter

### DIFF
--- a/lib/beautify-stack.js
+++ b/lib/beautify-stack.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function beautifyStack(stack) {
+	var re = /(?:^(?! {4}at\b).{6})|(?:\((?:[A-Z]:)?(?:[\\\/](?:(?!node_modules[\\\/]ava[\\\/])[^:\\\/])+)+:\d+:\d+\))/;
+	var found = false;
+
+	return stack.split('\n').filter(function (line) {
+		var relevant = re.test(line);
+		found = found || relevant;
+		return !found || relevant;
+	}).join('\n');
+}
+
+module.exports = beautifyStack;

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -1,0 +1,129 @@
+'use strict';
+var logUpdate = require('log-update');
+var chalk = require('chalk');
+var plur = require('plur');
+var beautifyStack = require('../beautify-stack');
+
+function MiniReporter() {
+	if (!(this instanceof MiniReporter)) {
+		return new MiniReporter();
+	}
+
+	this.passCount = 0;
+	this.failCount = 0;
+	this.rejectionCount = 0;
+	this.exceptionCount = 0;
+	this.finished = false;
+}
+
+module.exports = MiniReporter;
+
+MiniReporter.prototype.start = function () {
+	return '';
+};
+
+MiniReporter.prototype.test = function (test) {
+	var status = '\n';
+	var title;
+
+	if (test.skip) {
+		title = chalk.cyan('- ' + test.title);
+	} else if (test.error) {
+		title = chalk.red(test.title);
+		this.failCount++;
+	} else {
+		title = chalk.green(test.title);
+		this.passCount++;
+	}
+
+	status += '  ' + title;
+	status += '\n\n';
+
+	if (this.passCount > 0) {
+		status += '  ' + chalk.green(this.passCount, 'passed');
+	}
+
+	if (this.failCount > 0) {
+		status += '  ' + chalk.red(this.failCount, 'failed');
+	}
+
+	return status;
+};
+
+MiniReporter.prototype.unhandledError = function (err) {
+	if (err.type === 'exception') {
+		this.exceptionCount++;
+	} else {
+		this.rejectionCount++;
+	}
+};
+
+MiniReporter.prototype.finish = function () {
+	this.finished = true;
+
+	var status = '\n';
+
+	if (this.passCount > 0) {
+		status += '  ' + chalk.green(this.passCount, 'passed');
+	}
+
+	if (this.failCount > 0) {
+		status += '  ' + chalk.red(this.failCount, 'failed');
+	}
+
+	if (this.rejectionCount > 0) {
+		status += '\n  ' + chalk.red(this.rejectionCount, plur('rejection', this.rejectionCount));
+	}
+
+	if (this.exceptionCount > 0) {
+		status += '\n  ' + chalk.red(this.exceptionCount, plur('exception', this.exceptionCount));
+	}
+
+	var i = 0;
+
+	if (this.failCount > 0) {
+		this.api.tests.forEach(function (test) {
+			if (!test.error || !test.error.message) {
+				return;
+			}
+
+			i++;
+
+			var title = test.error ? test.title : 'Unhandled Error';
+			var description = test.error ? beautifyStack(test.error.stack) : JSON.stringify(test);
+
+			status += '\n\n  ' + chalk.red(i + '.', title) + '\n';
+			status += '  ' + chalk.red(description);
+		});
+	}
+
+	if (this.rejectionCount > 0 || this.exceptionCount > 0) {
+		this.api.errors.forEach(function (err) {
+			if (err.title) {
+				return;
+			}
+
+			i++;
+
+			var title = err.type === 'rejection' ? 'Unhandled Rejection' : 'Uncaught Exception';
+			var description = err.stack ? beautifyStack(err.stack) : JSON.stringify(err);
+
+			status += '\n\n  ' + chalk.red(i + '.', title) + '\n';
+			status += '  ' + chalk.red(description);
+		});
+	}
+
+	if (this.failCount === 0 && this.rejectionCount === 0 && this.exceptionCount === 0) {
+		status += '\n';
+	}
+
+	return status;
+};
+
+MiniReporter.prototype.write = function (str) {
+	logUpdate.stderr(str);
+
+	if (this.finished) {
+		logUpdate.stderr.done();
+	}
+};

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -3,17 +3,7 @@ var prettyMs = require('pretty-ms');
 var figures = require('figures');
 var chalk = require('chalk');
 var plur = require('plur');
-
-function beautifyStack(stack) {
-	var re = /(?:^(?! {4}at\b).{6})|(?:\((?:[A-Z]:)?(?:[\\\/](?:(?!node_modules[\\\/]ava[\\\/])[^:\\\/])+)+:\d+:\d+\))/;
-	var found = false;
-
-	return stack.split('\n').filter(function (line) {
-		var relevant = re.test(line);
-		found = found || relevant;
-		return !found || relevant;
-	}).join('\n');
-}
+var beautifyStack = require('../beautify-stack');
 
 function VerboseReporter() {
 	if (!(this instanceof VerboseReporter)) {
@@ -22,7 +12,6 @@ function VerboseReporter() {
 }
 
 module.exports = VerboseReporter;
-module.exports._beautifyStack = beautifyStack;
 
 VerboseReporter.prototype.start = function () {
 	return '';
@@ -90,7 +79,7 @@ VerboseReporter.prototype.finish = function () {
 		var i = 0;
 
 		this.api.tests.forEach(function (test) {
-			if (!test.error.message) {
+			if (!(test.error && test.error.message)) {
 				return;
 			}
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && tap --coverage --reporter=spec --timeout=150 test/*.js",
-    "test-win": "tap --reporter=spec --timeout=150 test/*.js",
+    "test": "xo && tap --coverage --reporter=spec --timeout=150 test/*.js test/reporters/*.js",
+    "test-win": "tap --reporter=spec --timeout=150 test/*.js test/reporters/*.js",
     "coverage": "tap --coverage-report=lcov"
   },
   "files": [
@@ -98,6 +98,7 @@
     "is-generator-fn": "^1.0.0",
     "is-observable": "^0.1.0",
     "is-promise": "^2.1.0",
+    "log-update": "^1.0.2",
     "loud-rejection": "^1.2.0",
     "max-timeout": "^1.0.0",
     "meow": "^3.6.0",

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,7 @@ $ ava --help
     --serial     Run tests serially
     --require    Module to preload (Can be repeated)
     --tap        Generate TAP output
+    --verbose    Enable verbose output
 
   Examples
     ava

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -2,6 +2,7 @@
 var figures = require('figures');
 var chalk = require('chalk');
 var test = require('tap').test;
+var beautifyStack = require('../../lib/beautify-stack');
 var verboseReporter = require('../../lib/reporters/verbose');
 
 function createReporter() {
@@ -18,7 +19,7 @@ test('beautify stack - removes uninteresting lines', function (t) {
 	try {
 		fooFunc();
 	} catch (err) {
-		var stack = verboseReporter._beautifyStack(err.stack);
+		var stack = beautifyStack(err.stack);
 		t.match(stack, /fooFunc/);
 		t.match(stack, /barFunc/);
 		t.match(err.stack, /Module._compile/);
@@ -69,7 +70,7 @@ test('don\'t display test title if there is only one anonymous test', function (
 		title: '[anonymous]'
 	});
 
-	t.is(output, undefined);
+	t.is(output, null);
 	t.end();
 });
 
@@ -78,7 +79,7 @@ test('failing test', function (t) {
 
 	var actualOutput = reporter.test({
 		title: 'failed',
-		err: {
+		error: {
 			message: 'assertion failed'
 		}
 	});


### PR DESCRIPTION
This PR fixes #18.

Replacing default reporter with a mini one:

![ava](https://cloud.githubusercontent.com/assets/697676/11973311/254f936a-a961-11e5-964f-73a05688e40c.gif)

It also adds `--verbose` option, which enables old full-blown output.
