### PR TITLE
Babel feature detection

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -85,7 +85,7 @@ if (prevHash === currHash) {
 		patterns: require('./enhance-assert').PATTERNS
 	});
 
-	options.presets = [require('babel-preset-stage-2'), require('babel-preset-es2015')];
+	options.presets = [require('babel-preset-stage-2'), require('babel-preset-features')];
 	options.plugins = [powerAssert, require('babel-plugin-transform-runtime')];
 
 	var transpiled = babel.transformFileSync(testPath, options);

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "babel-core": "^6.3.21",
     "babel-plugin-espower": "^2.0.0",
     "babel-plugin-transform-runtime": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-features": "^2.0.2",
     "babel-preset-stage-2": "^6.3.13",
     "babel-runtime": "^6.3.19",
     "bluebird": "^3.0.0",

--- a/test/api.js
+++ b/test/api.js
@@ -26,6 +26,17 @@ test('generators support', function (t) {
 		});
 });
 
+test('babel is only applied when needed', function (t) {
+	t.plan(1);
+
+	var api = new Api([path.join(__dirname, 'fixture/only-babel-when-needed.js')]);
+
+	api.run()
+		.then(function () {
+			t.is(api.passCount, 1);
+		});
+});
+
 test('async/await support', function (t) {
 	t.plan(1);
 

--- a/test/fixture/only-babel-when-needed.js
+++ b/test/fixture/only-babel-when-needed.js
@@ -1,0 +1,14 @@
+import test from '../../';
+
+var arrowFunction = foo => "bar";
+
+var arrowFunctionRaw = 'foo => "bar"';
+
+test(function (t) {
+	console.log('gen:', arrowFunction.toString());
+	if (['0.10.', '0.11.', '0.12.'].indexOf(process.versions.node.slice(0, 5)) === -1) {
+		t.is(arrowFunction.toString(), arrowFunctionRaw);
+	} else {
+		t.not(arrowFunction.toString(), arrowFunctionRaw);
+	}
+});


### PR DESCRIPTION
This fixes #348. It uses [`babel-preset-features`](http://npm.im/babel-preset-features) to auto-detect ES6 features. Also includes tests.

Enjoy!