### PR TITLE
Use AvaError for internal errors

### DIFF
--- a/api.js
+++ b/api.js
@@ -9,6 +9,7 @@ var figures = require('figures');
 var globby = require('globby');
 var chalk = require('chalk');
 var resolveCwd = require('resolve-cwd');
+var AvaError = require('./lib/ava-error');
 var fork = require('./lib/fork');
 var formatter = require('./lib/enhance-assert').formatter();
 
@@ -138,7 +139,7 @@ Api.prototype.run = function () {
 		})
 		.then(function (files) {
 			if (files.length === 0) {
-				return Promise.reject(new Error('Couldn\'t find any files to test'));
+				return Promise.reject(new AvaError('Couldn\'t find any files to test'));
 			}
 
 			self.fileCount = files.length;

--- a/cli.js
+++ b/cli.js
@@ -103,7 +103,7 @@ api.run()
 		logger.exit(api.failCount > 0 || api.rejectionCount > 0 || api.exceptionCount > 0 ? 1 : 0);
 	})
 	.catch(function (err) {
-		if (err.name === 'Error') {
+		if (err.name === 'AvaError') {
 			console.log('  ' + chalk.red(figures.cross) + ' ' + err.message);
 		} else {
 			console.error(err.stack);

--- a/lib/ava-error.js
+++ b/lib/ava-error.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function AvaError(message) {
+	if (!(this instanceof AvaError)) {
+		return new AvaError(message);
+	}
+
+	this.message = message;
+	this.name = 'AvaError';
+}
+
+module.exports = AvaError;

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -4,6 +4,7 @@ var path = require('path');
 var objectAssign = require('object-assign');
 var Promise = require('bluebird');
 var debug = require('debug')('ava');
+var AvaError = require('./ava-error');
 var send = require('./send');
 
 module.exports = function (file, opts) {
@@ -29,13 +30,13 @@ module.exports = function (file, opts) {
 
 		ps.on('exit', function (code) {
 			if (code > 0 && code !== 143) {
-				return reject(new Error(relFile + ' exited with a non-zero exit code: ' + code));
+				return reject(new AvaError(relFile + ' exited with a non-zero exit code: ' + code));
 			}
 
 			if (testResults) {
 				resolve(testResults);
 			} else {
-				reject(new Error('Test results were not received from ' + relFile));
+				reject(new AvaError('Test results were not received from ' + relFile));
 			}
 		});
 
@@ -48,7 +49,7 @@ module.exports = function (file, opts) {
 				message += ', make sure to import "ava" at the top of your test file';
 			}
 
-			reject(new Error(message));
+			reject(new AvaError(message));
 		});
 	});
 


### PR DESCRIPTION
This PR fixes #368.

Now we use `AvaError` for internal errors, that don't need a stack trace.