### PR TITLE
Include actual and expected when the number of assertions doesn't match the plan.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -8,6 +8,7 @@ var observableToPromise = require('observable-to-promise');
 var isPromise = require('is-promise');
 var isObservable = require('is-observable');
 var assert = require('./assert');
+var AvaError = require('./ava-error');
 var enhanceAssert = require('./enhance-assert');
 var globals = require('./globals');
 
@@ -75,10 +76,6 @@ Test.prototype.plan = function (count) {
 	}
 
 	this.planCount = count;
-
-	// in case the `planCount` doesn't match `assertCount,
-	// we need the stack of this function to throw with a useful stack
-	this.planStack = new Error().stack;
 };
 
 Test.prototype.run = function () {
@@ -174,14 +171,11 @@ Test.prototype._end = function (err) {
 
 Test.prototype._checkPlanCount = function () {
 	if (this.assertError === undefined && this.planCount !== null && this.planCount !== this.assertions.length) {
-		this._setAssertError(new assert.AssertionError({
-			actual: this.assertions.length,
-			expected: this.planCount,
-			message: 'Assertion count does not match planned',
-			operator: 'plan'
-		}));
+		var planError = new AvaError('Assertion count of ' + this.assertions.length + ' does not match plan of ' + this.planCount + '.');
+		planError.actual = this.assertions.length;
+		planError.expected = this.planCount;
 
-		this.assertError.stack = this.planStack;
+		this._setAssertError(planError);
 	}
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -88,6 +88,8 @@ test('run more assertions than planned', function (t) {
 	}).run().catch(function (err) {
 		t.ok(err);
 		t.is(err.name, 'AssertionError');
+		t.match(err.message, / 2( |\,|\.|\!)/, 'includes the expected number of assertions');
+		t.match(err.message, / 3( |\,|\.|\!)/, 'includes the actual number of assertions');
 		t.end();
 	});
 });


### PR DESCRIPTION
This isn't as good as it could be, as it doesn't have a nice assertion diff, because that's generated by power assert, which does all kinds of other things too that we don't want

Fixes #102.

@sindresorhus, @jamestalmage, @vdemedes: thoughs?