### PR TITLE
Deeply recurse directories

### DIFF
--- a/api.js
+++ b/api.js
@@ -195,7 +195,7 @@ function handlePaths(files) {
 		files = [
 			'test.js',
 			'test-*.js',
-			'test/*.js'
+			'test'
 		];
 	}
 
@@ -209,7 +209,7 @@ function handlePaths(files) {
 	return files
 		.map(function (file) {
 			if (fs.statSync(file).isDirectory()) {
-				return handlePaths([path.join(file, '*.js')]);
+				return handlePaths([path.join(file, '**', '*.js')]);
 			}
 
 			return file;

--- a/cli.js
+++ b/cli.js
@@ -48,11 +48,12 @@ var cli = meow([
 	'  ava',
 	'  ava test.js test2.js',
 	'  ava test-*.js',
+	'  ava test',
 	'  ava --init',
 	'  ava --init foo.js',
 	'',
 	'Default patterns when no arguments:',
-	'test.js test-*.js test/*.js'
+	'test.js test-*.js test/**/*.js'
 ], {
 	string: [
 		'_',

--- a/readme.md
+++ b/readme.md
@@ -115,14 +115,15 @@ $ ava --help
     ava
     ava test.js test2.js
     ava test-*.js
+    ava test
     ava --init
     ava --init foo.js
 
   Default patterns when no arguments:
-  test.js test-*.js test/*.js
+  test.js test-*.js test/**/*.js
 ```
 
-Files in directories named `fixtures` and `helpers` are ignored, as well as files starting with `_`. This can be useful for having helpers in the same directory as your test files.
+Directories are recursive by default. Files in directories named `fixtures` and `helpers` are ignored, as well as files starting with `_`. This can be useful for having helpers in the same directory as your test files.
 
 *WARNING: NON-STANDARD BEHAVIOR:* The AVA CLI will always try to find and use your projects local install of AVA. This is true even when you run the global `ava` command. This non-standard behavior solves an important [issue](https://github.com/sindresorhus/ava/issues/157), and should have no impact on everyday use.
 

--- a/test/api.js
+++ b/test/api.js
@@ -238,6 +238,18 @@ test('absolute paths', function (t) {
 		});
 });
 
+test('search directories recursivly for files', function (t) {
+	t.plan(1);
+
+	var api = new Api([path.join(__dirname, 'fixture/subdir')]);
+
+	api.run()
+		.then(function () {
+			t.is(api.passCount, 2);
+			t.is(api.failCount, 1);
+		});
+});
+
 test('titles of both passing and failing tests and AssertionErrors are returned', function (t) {
 	t.plan(3);
 

--- a/test/fixture/subdir/failing-subdir.js
+++ b/test/fixture/subdir/failing-subdir.js
@@ -1,0 +1,5 @@
+import test from '../../../';
+
+test('subdir fail', t => {
+	t.fail();
+});

--- a/test/fixture/subdir/in-a-subdir.js
+++ b/test/fixture/subdir/in-a-subdir.js
@@ -1,0 +1,5 @@
+import test from '../../../';
+
+test('subdir', t => {
+	t.pass();
+});

--- a/test/fixture/subdir/nested/nested.js
+++ b/test/fixture/subdir/nested/nested.js
@@ -1,0 +1,5 @@
+import test from '../../../../';
+
+test('subdir', t => {
+	t.pass();
+});


### PR DESCRIPTION
This changes the current behavior when a user specifies a directory in a glob pattern, i.e.:

Consider:

```
$ ava tests
```

Currently, this would only include all `.js` files in the `tests` directory, but not subdirectories. 

With this change, all `.js` files in the `tests` directory and all sub directories (infinitely deep) will be included.

Fixes #249.