### PR TITLE
Display power-assert output in mini reporter

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -82,7 +82,7 @@ MiniReporter.prototype.finish = function () {
 	var i = 0;
 
 	if (this.failCount > 0) {
-		this.api.tests.forEach(function (test) {
+		this.api.errors.forEach(function (test) {
 			if (!test.error || !test.error.message) {
 				return;
 			}
@@ -90,10 +90,17 @@ MiniReporter.prototype.finish = function () {
 			i++;
 
 			var title = test.error ? test.title : 'Unhandled Error';
-			var description = test.error ? beautifyStack(test.error.stack) : JSON.stringify(test);
+			var description;
+
+			if (test.error) {
+				description = '  ' + test.error.message;
+				description += '\n  ' + beautifyStack(test.error.stack);
+			} else {
+				description = JSON.stringify(test);
+			}
 
 			status += '\n\n  ' + chalk.red(i + '.', title) + '\n';
-			status += '  ' + chalk.red(description);
+			status += chalk.red(description);
 		});
 	}
 

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -137,7 +137,7 @@ test('results with errors', function (t) {
 	reporter.failCount = 1;
 
 	reporter.api = {
-		tests: [{
+		errors: [{
 			title: 'failed',
 			error: new Error('failure')
 		}]
@@ -149,7 +149,8 @@ test('results with errors', function (t) {
 	t.is(output[1], '  ' + chalk.red('1 failed'));
 	t.is(output[2], '');
 	t.is(output[3], '  ' + chalk.red('1. failed'));
-	t.match(output[4], /Error: failure/);
-	t.match(output[5], /Test\.test/);
+	t.match(output[4], /failure/);
+	t.match(output[5], /Error: failure/);
+	t.match(output[6], /Test\.test/);
 	t.end();
 });


### PR DESCRIPTION
This PR fixes #372.

Mini reporter (default one) was not displaying power-assert output. Now it does (along with a stack trace):

<img width="499" alt="screen shot 2015-12-27 at 11 34 43 pm" src="https://cloud.githubusercontent.com/assets/697676/12012190/7bf66b32-acf2-11e5-94fe-5a316dd167f5.png">

