### PR TITLE
Hide annoying error print outs.

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -12,7 +12,8 @@ module.exports = function (file, opts) {
 
 	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
 		cwd: path.dirname(file),
-		stdio: ['ignore', process.stderr, process.stderr]
+		stdio: ['ignore', process.stderr, process.stderr],
+		silent: opts.silent
 	});
 
 	var relFile = path.relative('.', file);

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
   "devDependencies": {
     "coveralls": "^2.11.4",
     "delay": "^1.3.0",
+    "get-stream": "^1.1.0",
     "signal-exit": "^2.1.2",
     "sinon": "^1.17.2",
     "source-map-fixtures": "^0.4.0",

--- a/test/fork.js
+++ b/test/fork.js
@@ -36,7 +36,7 @@ test('resolves promise with tests info', function (t) {
 test('rejects on error and streams output', function (t) {
 	t.plan(2);
 
-	fork(fixture('broken.js'))
+	fork(fixture('broken.js'), {silent: true})
 		.run()
 		.catch(function (err) {
 			t.ok(err);


### PR DESCRIPTION
Fixes #339.

To get the correct file and line number from `SyntexError`s, we need to give up control of how they are logged to console (see #308 for a full discussion on why this is true).

The unfortunate side effect was that tests exercising our syntax errors

I was not sure this was worth it (it is a lot of code two fix the output from just two tests), but then I [stumbled on this](https://github.com/sindresorhus/ava/commit/5e6327de2dcdc7a63d7d53f505673dbfd7973393). There seem to be situations where [a bad plan count, will not fail the tap test suite](https://github.com/isaacs/node-tap/issues/198). Now I think this is probably worth the effort.