### PR TITLE
Improve test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && tap --coverage --reporter=spec --timeout=150 test/*.js test/reporters/*.js",
-    "test-win": "tap --reporter=spec --timeout=150 test/*.js test/reporters/*.js",
-    "coverage": "tap --coverage-report=lcov"
+    "test": "xo && nyc --reporter=lcov --reporter=text tap --no-cov --timeout=150 test/*.js test/reporters/*.js",
+    "test-win": "tap --no-cov --reporter=classic --timeout=150 test/*.js test/reporters/*.js"
   },
   "files": [
     "lib",
@@ -129,14 +128,6 @@
     "tap": "^2.2.1",
     "xo": "*",
     "zen-observable": "^0.1.6"
-  },
-  "config": {
-    "nyc": {
-      "exclude": [
-        "node_modules[/\\\\]",
-        "test[/\\\\]"
-      ]
-    }
   },
   "xo": {
     "ignore": [


### PR DESCRIPTION
This uses `nyc` directly instead of via `tap`. There is currently some semver brokeness happening due to a major version bump in `nyc` making it's way into a minor version bump for `tap`. I think the easiest solution is just to avoid the problem altogether by turning off `tap`s coverage option and using `nyc` directly.

Reference:
  https://github.com/isaacs/node-tap/pull/197

---

This also switches us to the `classic` reporter. Historically were using `dots` reporter with `tape`, but that provided poor diagnostic information on failures. The `classic` reporter does a much better job of providing all the information we need when a test fails.