### PR TITLE
Support promises rejected with non-Errors

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -125,6 +125,14 @@ Test.prototype.run = function () {
 				self.exit();
 			})
 			.catch(function (err) {
+				if (!(err instanceof Error)) {
+					err = new assert.AssertionError({
+						actual: err,
+						message: 'Promise rejected with "' + err + '"',
+						operator: 'promise'
+					});
+				}
+
 				self._setAssertError(err);
 				self.exit();
 			});

--- a/test/promise.js
+++ b/test/promise.js
@@ -250,3 +250,14 @@ test('reject', function (t) {
 		t.end();
 	});
 });
+
+test('reject with non-Error', function (t) {
+	ava(function () {
+		return Promise.reject('failure');
+	}).run().catch(function (err) {
+		t.ok(err);
+		t.is(err.name, 'AssertionError');
+		t.is(err.message, 'Promise rejected with "failure"');
+		t.end();
+	});
+});


### PR DESCRIPTION
Fixes #386.

Previously, AVA expected `Error`s in rejected promises and did not support other types of rejected values. This resulted in a wrong output, marking failed tests as passed.

Now, if promise rejected with non-`Error`, we wrap it into `assert.AssertionError` to ensure promises always reject with `Error`s.