### PR TITLE
Use long stack traces in forks.

### DIFF
--- a/lib/test-worker.js
+++ b/lib/test-worker.js
@@ -23,6 +23,10 @@ if (debug.enabled) {
 
 // bind globals first before anything has a chance to interfere
 var globals = require('./globals');
+var Promise = require('bluebird');
+
+// Bluebird specific
+Promise.longStackTraces();
 
 (opts.require || []).forEach(require);
 


### PR DESCRIPTION
We currently only utilize long stack traces in the main thread, not the test threads. This rectifies that.

If we decide to drop Bluebird in forked processes (See #393), this is moot. But if we decide to keep bluebird around, we might as well enable this.