### PR TITLE
Stop reading `.babelrc` files.

### DIFF
--- a/test/fixture/babelrc/.babelrc
+++ b/test/fixture/babelrc/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["this-plugin-does-not-exist"]
+}

--- a/test/fixture/babelrc/package.json
+++ b/test/fixture/babelrc/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "application-name",
+  "version": "0.0.1"
+}

--- a/test/fixture/babelrc/test.js
+++ b/test/fixture/babelrc/test.js
@@ -1,0 +1,3 @@
+import test from '../../../'
+
+test(t => t.pass());

--- a/test/fork.js
+++ b/test/fork.js
@@ -81,3 +81,12 @@ test('destructuring of `t` is allowed', function (t) {
 			t.end();
 		});
 });
+
+test('babelrc is ignored', function (t) {
+	fork(fixture('babelrc/test.js'))
+	.run()
+	.then(function (info) {
+		t.is(info.stats.passCount, 1);
+		t.end();
+	});
+});


### PR DESCRIPTION
If a `.babelrc` file is present, it is being read, and the settings merged with the ones we specify for tests. We don't want that.

Reference:
 http://babeljs.io/docs/usage/options/