### PR TITLE
Rewrite all `require('babel-runtime/**)` statements to absolute paths

### DIFF
--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -25,6 +25,7 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 	var presetES2015 = require('babel-preset-es2015');
 	var transformRuntime = require('babel-plugin-transform-runtime');
 
+	var rewriteRuntime = this._createRewritePlugin();
 	var powerAssert = this._createEspowerPlugin(babel);
 
 	function buildOptions(filename, code) {
@@ -49,7 +50,7 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 		});
 
 		options.plugins = options.plugins || [];
-		options.plugins.push(powerAssert, transformRuntime);
+		options.plugins.push(powerAssert, transformRuntime, rewriteRuntime);
 
 		return options;
 	}
@@ -62,6 +63,22 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 		fs.writeFileSync(mapFile, JSON.stringify(result.map));
 		return result.code;
 	};
+};
+
+CachingPrecompiler.prototype._createRewritePlugin = function () {
+	var wrapListener = require('babel-plugin-detective/wrap-listener');
+
+	function rewriteRuntimeListener(path) {
+		if (path.isLiteral() && /^babel-runtime[\\\/]?/.test(path.node.value)) {
+			path.node.value = require.resolve(path.node.value);
+		}
+	}
+
+	return wrapListener(rewriteRuntimeListener, 'rewrite-runtime', {
+		generated: true,
+		require: true,
+		import: true
+	});
 };
 
 CachingPrecompiler.prototype._createEspowerPlugin = function (babel) {

--- a/lib/test-worker.js
+++ b/lib/test-worker.js
@@ -80,15 +80,6 @@ installPrecompiler(function (filename) {
 	return null;
 });
 
-// Modules need to be able to find `babel-runtime`, which is nested in our node_modules w/ npm@2
-var nodeModulesDir = path.join(__dirname, '../node_modules');
-var oldNodeModulesPaths = module.constructor._nodeModulePaths;
-module.constructor._nodeModulePaths = function () {
-	var ret = oldNodeModulesPaths.apply(this, arguments);
-	ret.push(nodeModulesDir);
-	return ret;
-};
-
 var dependencies = [];
 Object.keys(require.extensions).forEach(function (ext) {
 	var wrappedHandler = require.extensions[ext];

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "arrify": "^1.0.0",
     "ava-init": "^0.1.0",
     "babel-core": "^6.3.21",
+    "babel-plugin-detective": "^1.0.2",
     "babel-plugin-espower": "^2.1.0",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",

--- a/test/caching-precompiler.js
+++ b/test/caching-precompiler.js
@@ -96,11 +96,13 @@ test('uses babelConfig for babel options when babelConfig is an object', functio
 	var tempDir = uniqueTempDir();
 	var customPlugin = sinon.stub().returns({visitor: {}});
 	var powerAssert = sinon.stub().returns({visitor: {}});
+	var rewrite = sinon.stub().returns({visitor: {}});
 	var precompiler = new CachingPrecompiler(tempDir, {
 		presets: ['stage-2', 'es2015'],
 		plugins: [customPlugin]
 	});
 	sinon.stub(precompiler, '_createEspowerPlugin').returns(powerAssert);
+	sinon.stub(precompiler, '_createRewritePlugin').returns(rewrite);
 	babel.transform.reset();
 
 	precompiler.precompileFile(fixture('es2015.js'));
@@ -114,6 +116,6 @@ test('uses babelConfig for babel options when babelConfig is an object', functio
 	t.true('inputSourceMap' in options);
 	t.false(options.babelrc);
 	t.same(options.presets, ['stage-2', 'es2015']);
-	t.same(options.plugins, [customPlugin, powerAssert, transformRuntime]);
+	t.same(options.plugins, [customPlugin, powerAssert, transformRuntime, rewrite]);
 	t.end();
 });


### PR DESCRIPTION
I think messing with the module path is a bad idea, it seems like an easy way to create hard to reproduce bugs.

Also, if a user installs their own version of `babel-runtime`, we have no guarantee it is compatible with the one needed by our tests. By rewriting to absolute paths, we can completely bypass whatever version the user installs locally.

This PR adds a babel-plugin which rewrites all `babel-runtime` requires to absolute paths.