### PR TITLE
Make build badges more clear about their scope

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,10 @@
 
 > Futuristic test runner
 
-[![Build Status: Linux](https://travis-ci.org/sindresorhus/ava.svg?branch=master)](https://travis-ci.org/sindresorhus/ava) [![Build status: Windows](https://ci.appveyor.com/api/projects/status/igogxrcmhhm085co/branch/master?svg=true)](https://ci.appveyor.com/project/sindresorhus/ava/branch/master) [![Coverage Status](https://coveralls.io/repos/sindresorhus/ava/badge.svg?branch=master&service=github)](https://coveralls.io/github/sindresorhus/ava?branch=master) [![Gitter](https://img.shields.io/badge/Gitter-Join_the_AVA_chat_%E2%86%92-00d06f.svg)](https://gitter.im/sindresorhus/ava)
+[![Build Status: unix](https://img.shields.io/travis/sindresorhus/ava/master.svg?branch=master&label=unix build)](https://travis-ci.org/sindresorhus/ava)
+[![Build status: Windows](https://img.shields.io/appveyor/ci/sindresorhus/ava/master.svg?label=window build)](https://ci.appveyor.com/project/sindresorhus/ava/branch/master)
+[![Coverage Status](https://coveralls.io/repos/sindresorhus/ava/badge.svg?branch=master&service=github)](https://coveralls.io/github/sindresorhus/ava?branch=master)
+[![Gitter](https://img.shields.io/badge/Gitter-Join_the_AVA_chat_%E2%86%92-00d06f.svg)](https://gitter.im/sindresorhus/ava)
 
 Even though JavaScript is single-threaded, IO in Node.js can happen in parallel due to its async nature. AVA takes advantage of this and runs your tests concurrently, which is especially beneficial for IO heavy tests. In addition, test files are run in parallel as separate processes, giving you even better performance and an isolated environment for each test file. [Switching](https://github.com/sindresorhus/pageres/commit/663be15acb3dd2eb0f71b1956ef28c2cd3fdeed0) from Mocha to AVA in Pageres brought the test time down from 31 sec to 11 sec. Having tests run concurrently forces you to write atomic tests, meaning tests don't depend on global state or the state of other tests, which is a great thing!
 


### PR DESCRIPTION
"unix"/"window" labels seems to be more clear that just a weird additional icon for appveyor.
Also when not in a title, badges can be one per lines, since Markdown handle new lines as... nothing (unless you add 2 spaces before it, which add a br).