### PR TITLE
Add skipped test count to builtin reporters

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -11,6 +11,7 @@ function MiniReporter() {
 
 	this.passCount = 0;
 	this.failCount = 0;
+	this.skipCount = 0;
 	this.rejectionCount = 0;
 	this.exceptionCount = 0;
 	this.finished = false;
@@ -27,7 +28,8 @@ MiniReporter.prototype.test = function (test) {
 	var title;
 
 	if (test.skip) {
-		title = chalk.cyan('- ' + test.title);
+		title = chalk.yellow('- ' + test.title);
+		this.skipCount++;
 	} else if (test.error) {
 		title = chalk.red(test.title);
 		this.failCount++;
@@ -65,6 +67,10 @@ MiniReporter.prototype.finish = function () {
 
 	if (this.passCount > 0) {
 		status += '  ' + chalk.green(this.passCount, 'passed');
+	}
+
+	if (this.skipCount > 0) {
+		status += '  ' + chalk.yellow(this.skipCount, 'skipped');
 	}
 
 	if (this.failCount > 0) {

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -67,6 +67,7 @@ TapReporter.prototype.finish = function () {
 		'1..' + (this.api.passCount + this.api.failCount),
 		'# tests ' + (this.api.passCount + this.api.failCount),
 		'# pass ' + this.api.passCount,
+		'# skip ' + this.api.skipCount,
 		'# fail ' + (this.api.failCount + this.api.rejectionCount + this.api.exceptionCount),
 		''
 	];

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -65,6 +65,10 @@ VerboseReporter.prototype.finish = function () {
 		output += '  ' + chalk.green(this.api.passCount, plur('test', this.api.passCount), 'passed') + '\n';
 	}
 
+	if (this.api.skipCount > 0) {
+		output += '  ' + chalk.yellow(this.api.skipCount, plur('test', this.api.skipCount), 'skipped') + '\n';
+	}
+
 	if (this.api.rejectionCount > 0) {
 		output += '  ' + chalk.red(this.api.rejectionCount, 'unhandled', plur('rejection', this.api.rejectionCount)) + '\n';
 	}

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -59,7 +59,7 @@ test('skipped test', function (t) {
 
 	var expectedOutput = [
 		'',
-		'  ' + chalk.cyan('- skipped'),
+		'  ' + chalk.yellow('- skipped'),
 		'',
 		''
 	].join('\n');

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -84,6 +84,36 @@ test('results with passing tests', function (t) {
 	t.end();
 });
 
+test('results with skipped tests', function (t) {
+	var reporter = miniReporter();
+	reporter.passCount = 0;
+	reporter.skipCount = 1;
+	reporter.failCount = 0;
+
+	var actualOutput = reporter.finish();
+	var expectedOutput = [
+		'',
+		'  ' + chalk.yellow('1 skipped'),
+		''
+	].join('\n');
+
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});
+
+test('results with passing skipped tests', function (t) {
+	var reporter = miniReporter();
+	reporter.passCount = 1;
+	reporter.skipCount = 1;
+
+	var output = reporter.finish().split('\n');
+
+	t.is(output[0], '');
+	t.is(output[1], '  ' + chalk.green('1 passed') + '  ' + chalk.yellow('1 skipped'));
+	t.is(output[2], '');
+	t.end();
+});
+
 test('results with passing tests and rejections', function (t) {
 	var reporter = miniReporter();
 	reporter.passCount = 1;

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -81,6 +81,7 @@ test('results', function (t) {
 	var api = {
 		passCount: 1,
 		failCount: 2,
+		skipCount: 1,
 		rejectionCount: 3,
 		exceptionCount: 4
 	};
@@ -93,6 +94,7 @@ test('results', function (t) {
 		'1..' + (api.passCount + api.failCount),
 		'# tests ' + (api.passCount + api.failCount),
 		'# pass ' + api.passCount,
+		'# skip ' + api.skipCount,
 		'# fail ' + (api.failCount + api.rejectionCount + api.exceptionCount),
 		''
 	].join('\n');

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -165,6 +165,23 @@ test('results with passing tests', function (t) {
 	t.end();
 });
 
+test('results with skipped tests', function (t) {
+	var reporter = createReporter();
+	reporter.api.passCount = 1;
+	reporter.api.skipCount = 1;
+
+	var actualOutput = reporter.finish();
+	var expectedOutput = [
+		'',
+		'  ' + chalk.green('1 test passed'),
+		'  ' + chalk.yellow('1 test skipped'),
+		''
+	].join('\n');
+
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});
+
 test('results with passing tests and rejections', function (t) {
 	var reporter = createReporter();
 	reporter.api.passCount = 1;


### PR DESCRIPTION
This fixes https://github.com/sindresorhus/ava/issues/408 by adding the skipped test count to the builtin reporters, in yellow color.

Let me know if I missed anything or if another color is more appropriate.