### PR TITLE
Fix t.throws/doesNotThrow not outputting failure reason

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -75,7 +75,11 @@ x.throws = function (fn, err, msg) {
 				x.throws(noop, err, msg);
 			}, function (fnErr) {
 				x.throws(function () {
-					throw fnErr;
+					if (fnErr.message) {
+						throw fnErr;
+					} else {
+						throw new Error(fnErr);
+					}
 				}, err, msg);
 			});
 	}

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -75,7 +75,7 @@ x.throws = function (fn, err, msg) {
 				x.throws(noop, err, msg);
 			}, function (fnErr) {
 				x.throws(function () {
-					if (fnErr.message) {
+					if (fnErr instanceof Error) {
 						throw fnErr;
 					} else {
 						throw new Error(fnErr);

--- a/test/promise.js
+++ b/test/promise.js
@@ -177,6 +177,30 @@ test('handle throws with string', function (t) {
 	});
 });
 
+test('handle throws with regex with string reject', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.reject('abc');
+		return a.throws(promise, /abc/);
+	}).run().then(function (a) {
+		t.notOk(a.assertionError);
+		t.end();
+	});
+});
+
+test('handle throws with string with string reject', function (t) {
+	ava(function (a) {
+		a.plan(1);
+
+		var promise = Promise.reject('abc');
+		return a.throws(promise, 'abc');
+	}).run().then(function (a) {
+		t.notOk(a.assertionError);
+		t.end();
+	});
+});
+
 test('handle throws with false-positive promise', function (t) {
 	ava(function (a) {
 		a.plan(1);


### PR DESCRIPTION
If a Promise is rejected with a string, `t.throws()` fails the test with "undefined undefined undefined" instead of the label of the assertion or any other identifying information, leaving the dev writing the tests unable to easily pinpoint which test has just failed.

Reproduce by writing a `t.throws()` assertion for a Promise that rejects simply using a string and have a RegExp validation rule.

Before:
```
  1 failed

  1. rejects
  undefined undefined undefined
  AssertionError: undefined undefined undefined
```

After:
```
  1 failed

  1. rejects
  Invalid due date 19791224T245051Z
  AssertionError: Invalid due date 19791224T245051Z
```