### PR TITLE
Use stack-utils for nicer stack traces.

### DIFF
--- a/lib/beautify-stack.js
+++ b/lib/beautify-stack.js
@@ -1,13 +1,18 @@
 'use strict';
 
-function beautifyStack(stack) {
-	var re = /(?:^(?! {4}at\b).{6})|(?:\((?:[A-Z]:)?(?:[\\\/](?:(?!node_modules[\\\/]ava[\\\/])[^:\\\/])+)+:\d+:\d+\))/;
-	var found = false;
+var StackUtils = require('stack-utils');
+var debug = require('debug')('ava');
 
-	return stack.split('\n').filter(function (line) {
-		var relevant = re.test(line);
-		found = found || relevant;
-		return !found || relevant;
+var stackUtils = new StackUtils({
+	internals: debug.enabled ? [] : StackUtils.nodeInternals().concat([
+		/\/ava\/(?:lib\/)?[\w-]+\.js:\d+:\d+\)?$/,
+		/\/node_modules\/(?:bluebird|empower-core)\//
+	])
+});
+
+function beautifyStack(stack) {
+	return stack.split('\n')[0] + '\n' + stackUtils.clean(stack).split('\n').map(function (s) {
+		return '    ' + s;
 	}).join('\n');
 }
 

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "serialize-error": "^1.1.0",
     "set-immediate-shim": "^1.0.1",
     "source-map-support": "^0.4.0",
+    "stack-utils": "^0.3.0",
     "strip-bom": "^2.0.0",
     "time-require": "^0.1.2",
     "unique-temp-dir": "^1.0.0",

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -129,7 +129,7 @@ test('results with passing tests and rejections', function (t) {
 	t.is(output[2], '');
 	t.is(output[3], '  ' + chalk.red('1. Unhandled Rejection'));
 	t.match(output[4], /Error: failure/);
-	t.match(output[5], /Test\.test/);
+	t.match(output[5], /test\/reporters\/mini\.js/);
 	t.end();
 });
 
@@ -152,7 +152,7 @@ test('results with passing tests and exceptions', function (t) {
 	t.is(output[2], '');
 	t.is(output[3], '  ' + chalk.red('1. Uncaught Exception'));
 	t.match(output[4], /Error: failure/);
-	t.match(output[5], /Test\.test/);
+	t.match(output[5], /test\/reporters\/mini\.js/);
 	t.end();
 });
 
@@ -174,6 +174,6 @@ test('results with errors', function (t) {
 	t.is(output[2], '  ' + chalk.red('1. failed'));
 	t.match(output[3], /failure/);
 	t.match(output[4], /Error: failure/);
-	t.match(output[5], /Test\.test/);
+	t.match(output[5], /test\/reporters\/mini\.js/);
 	t.end();
 });

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -115,7 +115,7 @@ test('uncaught exception', function (t) {
 
 	t.is(output[0], chalk.red('Uncaught Exception: test.js'));
 	t.match(output[1], /Error: Unexpected token/);
-	t.match(output[2], /at Test\.test/);
+	t.match(output[2], /test\/reporters\/verbose\.js/);
 	t.end();
 });
 
@@ -130,7 +130,7 @@ test('unhandled rejection', function (t) {
 
 	t.is(output[0], chalk.red('Unhandled Rejection: test.js'));
 	t.match(output[1], /Error: Unexpected token/);
-	t.match(output[2], /at Test\.test/);
+	t.match(output[2], /test\/reporters\/verbose\.js/);
 	t.end();
 });
 
@@ -248,7 +248,7 @@ test('results with errors', function (t) {
 	t.is(output[1], '  ' + chalk.red('1 test failed'));
 	t.is(output[3], '  ' + chalk.red('1. fail'));
 	t.match(output[4], /Error: error message/);
-	t.match(output[5], /Test\.test/);
+	t.match(output[5], /test\/reporters\/verbose\.js/);
 	t.end();
 });
 


### PR DESCRIPTION
I have extracted `node-tap`s stack cleaning algorithm into it's own module, [`tapjs/stack-utils`](https://github.com/tapjs/stack-utils).

It creates much nicer stack traces than `beautify-stack.js` does. There is a bit of work left to do in the `stack-utils` module, but once these are done, this should be mergeable:

 - [x] https://github.com/tapjs/stack-utils/issues/8 - decide what should be considered `internal`
 - [x] https://github.com/tapjs/stack-utils/pull/6 - clean long stack traces

Screenshots below.