### PR TITLE
Bump dependencies for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,8 +137,8 @@
     "rimraf": "^2.5.0",
     "signal-exit": "^2.1.2",
     "sinon": "^1.17.2",
-    "source-map-fixtures": "^0.4.0",
-    "tap": "^2.2.1",
+    "source-map-fixtures": "^1.0.0",
+    "tap": "^5.0.1",
     "xo": "*",
     "zen-observable": "^0.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ava-init": "^0.1.0",
     "babel-core": "^6.3.21",
     "babel-plugin-espower": "^2.1.0",
+    "babel-plugin-transform-regenerator": "6.3.26",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",


### PR DESCRIPTION
Skipping `observable-to-promise` for this release because of https://github.com/sindresorhus/observable-to-promise/issues/2

`babel-plugin-transform-regenerator` intentionally held back due to regression in babel (9cf22c3).