### PR TITLE
bump observable-to-promise

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -2,6 +2,7 @@
 var assert = require('core-assert');
 var deepEqual = require('deeper');
 var observableToPromise = require('observable-to-promise');
+var isObservable = require('is-observable');
 var isPromise = require('is-promise');
 var x = module.exports;
 
@@ -67,7 +68,9 @@ x.notSame = function (val, expected, msg) {
 };
 
 x.throws = function (fn, err, msg) {
-	fn = observableToPromise(fn);
+	if (isObservable(fn)) {
+		fn = observableToPromise(fn);
+	}
 
 	if (isPromise(fn)) {
 		return fn
@@ -99,7 +102,9 @@ x.throws = function (fn, err, msg) {
 };
 
 x.doesNotThrow = function (fn, msg) {
-	fn = observableToPromise(fn);
+	if (isObservable(fn)) {
+		fn = observableToPromise(fn);
+	}
 
 	if (isPromise(fn)) {
 		return fn

--- a/lib/test.js
+++ b/lib/test.js
@@ -261,7 +261,8 @@ Test.prototype._publicApi = function () {
 			event.error.powerAssertContext = event.powerAssertContext;
 			promise = Promise.reject(event.error);
 		} else {
-			promise = Promise.resolve(observableToPromise(event.returnValue));
+			var ret = event.returnValue;
+			promise = isObservable(ret) ? observableToPromise(ret) : Promise.resolve(ret);
 		}
 		promise = promise
 			.catch(function (err) {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "md5-hex": "^1.2.0",
     "meow": "^3.7.0",
     "object-assign": "^4.0.1",
-    "observable-to-promise": "^0.1.0",
+    "observable-to-promise": "^0.3.0",
     "pkg-conf": "^1.0.1",
     "plur": "^2.0.0",
     "power-assert-formatter": "^1.3.0",


### PR DESCRIPTION
Observable `0.2.0`/`0.3.0` introduced some breaking changes. Namely, it now throws if passed a non-observable.

Reference: https://github.com/sindresorhus/observable-to-promise/issues/2