### PR TITLE
Allow files with only skipped tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,8 +69,9 @@ function exit() {
 
 globals.setImmediate(function () {
 	var numberOfTests = runner.select({type: 'test', skipped: false}).length;
+	var numberOfSkippedTests = runner.select({type: 'test', skipped: true}).length;
 
-	if (numberOfTests === 0) {
+	if (numberOfTests === 0 && numberOfSkippedTests === 0) {
 		send('no-tests', {avaRequired: true});
 		return;
 	}

--- a/index.js
+++ b/index.js
@@ -68,10 +68,9 @@ function exit() {
 }
 
 globals.setImmediate(function () {
-	var numberOfTests = runner.select({type: 'test', skipped: false}).length;
-	var numberOfSkippedTests = runner.select({type: 'test', skipped: true}).length;
+	var numberOfTests = runner.select({type: 'test'}).length;
 
-	if (numberOfTests === 0 && numberOfSkippedTests === 0) {
+	if (numberOfTests === 0) {
 		send('no-tests', {avaRequired: true});
 		return;
 	}

--- a/test/api.js
+++ b/test/api.js
@@ -475,3 +475,15 @@ test('caching can be disabled', function (t) {
 			t.end();
 		});
 });
+
+test('test file with only skipped tests does not create a failure', function (t) {
+	t.plan(2);
+
+	var api = new Api([path.join(__dirname, 'fixture/skip-only.js')]);
+
+	api.run()
+		.then(function () {
+			t.is(api.tests.length, 1);
+			t.true(api.tests[0].skip);
+		});
+});

--- a/test/fixture/skip-only.js
+++ b/test/fixture/skip-only.js
@@ -1,0 +1,5 @@
+import test from '../../';
+
+test.skip(t => {
+	t.fail();
+});


### PR DESCRIPTION
Ensures that skipped tests are also counted when determining whether or not a file contains tests. My own use-case is a multi-file test suite where one or more test files contain nothing but skipped tests due to them testing functionality yet to be implemented.