### PR TITLE
Revert "lock `babel-plugin-transform-regenerator` dependency to fix #425"

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "ava-init": "^0.1.0",
     "babel-core": "^6.3.21",
     "babel-plugin-espower": "^2.1.0",
-    "babel-plugin-transform-regenerator": "6.3.26",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",


### PR DESCRIPTION
This reverts commit 08c3285c3897dde404d698e5f5038edc3f786ca7.

The issue in transform-regenerator has been fixed as of `6.4.4`