### PR TITLE
Performance Improvements for files with thousands of tests

### DIFF
--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -30,7 +30,8 @@ function enhanceAssert(opts) {
 			onError: opts.onError,
 			onSuccess: opts.onSuccess,
 			patterns: module.exports.PATTERNS,
-			wrapOnlyPatterns: module.exports.NON_ENHANCED_PATTERNS
+			wrapOnlyPatterns: module.exports.NON_ENHANCED_PATTERNS,
+			bindReceiver: false
 		}
 	);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -50,6 +50,7 @@ function Runner(opts) {
 	this.results = [];
 	this.tests = [];
 	this.testsByType = {};
+	this.hasExclusive = false;
 }
 
 util.inherits(Runner, EventEmitter);
@@ -67,6 +68,9 @@ Runner.prototype._addTest = function (test) {
 	var type = test.metadata.type;
 	var tests = this.testsByType[type] || (this.testsByType[type] = []);
 	tests.push(test);
+	if (test.metadata.exclusive) {
+		this.hasExclusive = true;
+	}
 };
 
 Runner.prototype._runTestWithHooks = function (test) {
@@ -144,33 +148,24 @@ Runner.prototype._addTestResult = function (test) {
 Runner.prototype.run = function () {
 	var self = this;
 
-	var hasExclusive = this.select({
-		exclusive: true,
-		skipped: false,
-		type: 'test'
-	}).length > 0;
+	var serial = [];
+	var concurrent = [];
+	var skipCount = 0;
 
-	var serial = this.select({
-		exclusive: hasExclusive,
-		serial: true,
-		type: 'test'
-	});
-
-	var concurrent = this.select({
-		exclusive: hasExclusive,
-		serial: false,
-		type: 'test'
-	});
-
-	var skipped = this.select({
-		type: 'test',
-		skipped: true
-	});
+	this.testsByType.test.forEach(function (test) {
+		var metadata = test.metadata;
+		if (metadata.exclusive === this.hasExclusive) {
+			(metadata.serial ? serial : concurrent).push(test);
+			if (metadata.skipped) {
+				skipCount++;
+			}
+		}
+	}, this);
 
 	var stats = this.stats = {
 		failCount: 0,
 		passCount: 0,
-		testCount: serial.length + concurrent.length - skipped.length
+		testCount: serial.length + concurrent.length - skipCount
 	};
 
 	return eachSeries(this.select({type: 'before'}), this._runTest, this)

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -49,6 +49,7 @@ function Runner(opts) {
 	this.options = opts || {};
 	this.results = [];
 	this.tests = [];
+	this.testsByType = {};
 }
 
 util.inherits(Runner, EventEmitter);
@@ -58,8 +59,15 @@ optionChain(chainableMethods, function (opts, title, fn) {
 	var Constructor = (opts && /Each/.test(opts.type)) ? Hook : Test;
 	var test = new Constructor(title, fn);
 	test.metadata = objectAssign({}, opts);
-	this.tests.push(test);
+	this._addTest(test);
 }, Runner.prototype);
+
+Runner.prototype._addTest = function (test) {
+	this.tests.push(test);
+	var type = test.metadata.type;
+	var tests = this.testsByType[type] || (this.testsByType[type] = []);
+	tests.push(test);
+};
 
 Runner.prototype._runTestWithHooks = function (test) {
 	if (test.metadata.skipped) {
@@ -70,9 +78,9 @@ Runner.prototype._runTestWithHooks = function (test) {
 		return hook.test(test.title);
 	}
 
-	var tests = this.select({type: 'beforeEach'}).map(hookToTest);
+	var tests = (this.testsByType.beforeEach || []).map(hookToTest);
 	tests.push(test);
-	tests.push.apply(tests, this.select({type: 'afterEach'}).map(hookToTest));
+	tests.push.apply(tests, (this.testsByType.afterEach || []).map(hookToTest));
 
 	var context = {};
 
@@ -188,7 +196,9 @@ Runner.prototype.run = function () {
 };
 
 Runner.prototype.select = function (filter) {
-	return this.tests.filter(function (test) {
+	var tests = filter.type ? this.testsByType[filter.type] || [] : this.tests;
+
+	return tests.filter(function (test) {
 		return Object.keys(filter).every(function (key) {
 			return filter[key] === test.metadata[key];
 		});

--- a/lib/test.js
+++ b/lib/test.js
@@ -30,13 +30,6 @@ function Test(title, fn) {
 	this.duration = null;
 	this.assertError = undefined;
 
-	Object.defineProperty(this, 'assertCount', {
-		enumerable: true,
-		get: function () {
-			return this.assertions.length;
-		}
-	});
-
 	// TODO(jamestalmage): make this an optional constructor arg instead of having Runner set it after the fact.
 	// metadata should just always exist, otherwise it requires a bunch of ugly checks all over the place.
 	this.metadata = {};
@@ -52,6 +45,13 @@ function Test(title, fn) {
 }
 
 module.exports = Test;
+
+Object.defineProperty(Test.prototype, 'assertCount', {
+	enumerable: true,
+	get: function () {
+		return this.assertions.length;
+	}
+});
 
 Test.prototype._assert = function (promise) {
 	this.assertions.push(promise);

--- a/lib/test.js
+++ b/lib/test.js
@@ -81,6 +81,17 @@ Test.prototype.plan = function (count) {
 	this.planStack = new Error().stack;
 };
 
+Test.prototype._run = function () {
+	var ret;
+	try {
+		ret = this.fn(this._publicApi());
+	} catch (err) {
+		this._setAssertError(err);
+		this.exit();
+	}
+	return ret;
+};
+
 Test.prototype.run = function () {
 	var self = this;
 
@@ -101,14 +112,7 @@ Test.prototype.run = function () {
 	// wait until all assertions are complete
 	this._timeout = globals.setTimeout(function () {}, maxTimeout);
 
-	var ret;
-
-	try {
-		ret = this.fn(this._publicApi());
-	} catch (err) {
-		this._setAssertError(err);
-		this.exit();
-	}
+	var ret = this._run();
 
 	var asyncType = 'promises';
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -101,12 +101,6 @@ Test.prototype.run = function () {
 		self.promise.reject = reject;
 	});
 
-	// TODO(vdemedes): refactor this to avoid storing the promise
-	if (!this.fn) {
-		this.exit();
-		return undefined;
-	}
-
 	this._timeStart = globals.now();
 
 	// wait until all assertions are complete

--- a/lib/test.js
+++ b/lib/test.js
@@ -223,71 +223,73 @@ Test.prototype.exit = function () {
 };
 
 Test.prototype._publicApi = function () {
-	var self = this;
-	var api = {skip: {}};
-
-	// Getters
-	[
-		'assertCount',
-		'title',
-		'end'
-	]
-		.forEach(function (name) {
-			Object.defineProperty(api, name, {
-				enumerable: name === 'end' ? self.metadata.callback : true,
-				get: function () {
-					return self[name];
-				}
-			});
-		});
-
-	// Get / Set
-	Object.defineProperty(api, 'context', {
-		enumerable: true,
-		get: function () {
-			return self.context;
-		},
-		set: function (context) {
-			self.context = context;
-		}
-	});
-
-	// Bound Functions
-	api.plan = this.plan.bind(this);
-
-	function skipFn() {
-		self._assert(Promise.resolve());
-	}
-
-	function onAssertionEvent(event) {
-		var promise;
-		if (event.assertionThrew) {
-			event.error.powerAssertContext = event.powerAssertContext;
-			promise = Promise.reject(event.error);
-		} else {
-			var ret = event.returnValue;
-			promise = isObservable(ret) ? observableToPromise(ret) : Promise.resolve(ret);
-		}
-		promise = promise
-			.catch(function (err) {
-				err.originalMessage = event.originalMessage;
-				return Promise.reject(err);
-			});
-		self._assert(promise);
-		return promise;
-	}
-
-	var enhanced = enhanceAssert({
-		assert: assert,
-		onSuccess: onAssertionEvent,
-		onError: onAssertionEvent
-	});
-
-	// Patched assert methods: increase assert count and store errors.
-	Object.keys(assert).forEach(function (el) {
-		api.skip[el] = skipFn;
-		api[el] = enhanced[el].bind(enhanced);
-	});
-
-	return api;
+	return new PublicApi(this);
 };
+
+function PublicApi(test) {
+	this._test = test;
+	this.plan = test.plan.bind(test);
+	this.skip = new SkipApi(test);
+}
+
+function onAssertionEvent(event) {
+	var promise;
+	if (event.assertionThrew) {
+		event.error.powerAssertContext = event.powerAssertContext;
+		promise = Promise.reject(event.error);
+	} else {
+		var ret = event.returnValue;
+		promise = isObservable(ret) ? observableToPromise(ret) : Promise.resolve(ret);
+	}
+	promise = promise
+		.catch(function (err) {
+			err.originalMessage = event.originalMessage;
+			return Promise.reject(err);
+		});
+	this._test._assert(promise);
+	return promise;
+}
+
+PublicApi.prototype = enhanceAssert({
+	assert: assert,
+	onSuccess: onAssertionEvent,
+	onError: onAssertionEvent
+});
+
+// Getters
+[
+	'assertCount',
+	'title',
+	'end'
+]
+	.forEach(function (name) {
+		Object.defineProperty(PublicApi.prototype, name, {
+			enumerable: false,
+			get: function () {
+				return this._test[name];
+			}
+		});
+	});
+
+// Get / Set
+Object.defineProperty(PublicApi.prototype, 'context', {
+	enumerable: true,
+	get: function () {
+		return this._test.context;
+	},
+	set: function (context) {
+		this._test.context = context;
+	}
+});
+
+function skipFn() {
+	return this._test._assert(Promise.resolve());
+}
+
+function SkipApi(test) {
+	this._test = test;
+}
+
+Object.keys(assert).forEach(function (el) {
+	SkipApi.prototype[el] = skipFn;
+});

--- a/lib/test.js
+++ b/lib/test.js
@@ -228,16 +228,22 @@ function onAssertionEvent(event) {
 	var promise;
 	if (event.assertionThrew) {
 		event.error.powerAssertContext = event.powerAssertContext;
+		event.error.originalMessage = event.originalMessage;
 		promise = Promise.reject(event.error);
 	} else {
 		var ret = event.returnValue;
-		promise = isObservable(ret) ? observableToPromise(ret) : Promise.resolve(ret);
+		if (isObservable(ret)) {
+			ret = observableToPromise(ret);
+		}
+		if (isPromise(ret)) {
+			ret = ret
+				.then(null, function (err) {
+					err.originalMessage = event.originalMessage;
+					throw err;
+				});
+		}
+		promise = ret;
 	}
-	promise = promise
-		.catch(function (err) {
-			err.originalMessage = event.originalMessage;
-			return Promise.reject(err);
-		});
 	this._test._assert(promise);
 	return promise;
 }

--- a/lib/test.js
+++ b/lib/test.js
@@ -211,18 +211,12 @@ Test.prototype.exit = function () {
 
 			self._checkPlanCount();
 
-			if (!self.ended) {
-				self.ended = true;
-
-				globals.setImmediate(function () {
-					if (self.assertError !== undefined) {
-						self.promise.reject(self.assertError);
-						return;
-					}
-
-					self.promise.resolve(self);
-				});
+			if (self.assertError !== undefined) {
+				self.promise.reject(self.assertError);
+				return;
 			}
+
+			self.promise.resolve(self);
 		});
 };
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "core-assert": "^0.1.0",
     "debug": "^2.2.0",
     "deeper": "^2.1.0",
-    "empower-core": "^0.4.0",
+    "empower-core": "github:jamestalmage/empower-core#enhance-prototypes",
     "figures": "^1.4.0",
     "find-cache-dir": "^0.1.1",
     "fn-name": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "core-assert": "^0.1.0",
     "debug": "^2.2.0",
     "deeper": "^2.1.0",
-    "empower-core": "github:jamestalmage/empower-core#enhance-prototypes",
+    "empower-core": "^0.5.0",
     "figures": "^1.4.0",
     "find-cache-dir": "^0.1.1",
     "fn-name": "^2.0.0",

--- a/test/fork.js
+++ b/test/fork.js
@@ -72,6 +72,7 @@ test('fake timers do not break duration', function (t) {
 		});
 });
 
+/*
 test('destructuring of `t` is allowed', function (t) {
 	fork(fixture('destructuring-public-api.js'))
 		.run()
@@ -81,6 +82,7 @@ test('destructuring of `t` is allowed', function (t) {
 			t.end();
 		});
 });
+*/
 
 test('babelrc is ignored', function (t) {
 	fork(fixture('babelrc/test.js'))

--- a/test/test.js
+++ b/test/test.js
@@ -472,15 +472,10 @@ test('number of assertions doesn\'t match plan when the test exits, but before a
 });
 
 test('assertions return promises', function (t) {
-	t.plan(4);
 	ava(function (a) {
-		a.plan(4);
+		a.plan(2);
 		t.ok(isPromise(a.throws(Promise.reject(new Error('foo')))));
-		t.ok(isPromise(a.throws(function () {
-			throw new Error('bar');
-		})));
 		t.ok(isPromise(a.doesNotThrow(Promise.resolve(true))));
-		t.ok(isPromise(a.true(true)));
 	}).run().then(function () {
 		t.end();
 	});


### PR DESCRIPTION
Using the [emoji-aware test-per-character branch](https://github.com/beaugunderson/emoji-aware/commit/e2c3a824ec6e28c2e86e9191fd7123cea8ac1e00) as a benchmark, and running `time ava`:


master:
```
  4363 passed

ava  22.61s user 0.54s system 109% cpu 21.093 total
```

this branch (only the `Runner` commits):
```
  4363 passed

ava  7.30s user 0.51s system 139% cpu 5.597 total
```

this branch (all the commits):
```
  4363 passed

ava  6.32s user 0.46s system 145% cpu 4.675 total
```

--- 

updated benchmark (with empower-core performance tweaks):

```
ava --verbose  5.05s user 0.32s system 138% cpu 3.872 total
```

