### PR TITLE
Fix undefined skip count

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -66,11 +66,14 @@ TapReporter.prototype.finish = function () {
 		'',
 		'1..' + (this.api.passCount + this.api.failCount),
 		'# tests ' + (this.api.passCount + this.api.failCount),
-		'# pass ' + this.api.passCount,
-		'# skip ' + this.api.skipCount,
-		'# fail ' + (this.api.failCount + this.api.rejectionCount + this.api.exceptionCount),
-		''
+		'# pass ' + this.api.passCount
 	];
+
+	if (this.api.skipCount > 0) {
+		output.push('# skip ' + this.api.skipCount);
+	}
+
+	output.push('# fail ' + (this.api.failCount + this.api.rejectionCount + this.api.exceptionCount), '');
 
 	return output.join('\n');
 };

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -102,3 +102,29 @@ test('results', function (t) {
 	t.is(actualOutput, expectedOutput);
 	t.end();
 });
+
+test('results does not show skipped tests if there are none', function (t) {
+	var reporter = tapReporter();
+	var api = {
+		passCount: 1,
+		failCount: 2,
+		skipCount: 0,
+		rejectionCount: 3,
+		exceptionCount: 4
+	};
+
+	reporter.api = api;
+
+	var actualOutput = reporter.finish();
+	var expectedOutput = [
+		'',
+		'1..' + (api.passCount + api.failCount),
+		'# tests ' + (api.passCount + api.failCount),
+		'# pass ' + api.passCount,
+		'# fail ' + (api.failCount + api.rejectionCount + api.exceptionCount),
+		''
+	].join('\n');
+
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});


### PR DESCRIPTION
This fixes #423 by only outputting the skipped test count in the TAP reporter if there are skipped tests. If there are none, it does not output anything. It also adds a test for this.

[tape](https://github.com/substack/tape/blob/master/lib/results.js#L132) does this and so does [tap](https://github.com/tapjs/node-tap/blob/master/lib/test.js#L882) (thanks to @therealklanni for the line reference for tap!).