### PR TITLE
Add links translations for new docs

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,5 +1,7 @@
 # Contributor Code of Conduct
 
+Translations: [Español](https://github.com/sindresorhus/ava-docs/blob/master/es_ES/code-of-conduct.md), [Français](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/code-of-conduct.md)
+
 As contributors and maintainers of this project, and in the interest of
 fostering an open and welcoming community, we pledge to respect all people who
 contribute through reporting issues, posting feature requests, updating

--- a/docs/recipes/code-coverage.md
+++ b/docs/recipes/code-coverage.md
@@ -1,5 +1,7 @@
 # Code coverage
 
+Translations: [Español](https://github.com/sindresorhus/ava-docs/blob/master/es_ES/docs/recipes/code-coverage.md), [Français](https://github.com/sindresorhus/ava-docs/blob/master/fr_FR/docs/recipes/code-coverage.md)
+
 As AVA [spawns the test files][isolated-env], you can't use [`istanbul`] for code coverage; instead, you can achieve this with [`nyc`] which is basically [`istanbul`] with sub-process support. 
 
 ## Setup

--- a/docs/recipes/endpoint-testing.md
+++ b/docs/recipes/endpoint-testing.md
@@ -1,5 +1,7 @@
 # Endpoint testing
 
+Translations: [Español](https://github.com/sindresorhus/ava-docs/blob/master/es_ES/docs/recipes/endpoint-testing.md), [Français](endpoint-testing.md)
+
 AVA doesn't have a builtin method for testing endpoints, but you can use any assertion library with it. Let's use [`supertest-as-promised`](https://github.com/WhoopInc/supertest-as-promised).
 
 Since tests run concurrently, it's best to create a fresh server instance for each test, because if we referenced the same instance, it could be mutated between tests. This can be accomplished with a `test.beforeEach` and `t.context`, or with simply a factory function:


### PR DESCRIPTION
* code of conduct (Spanish & French)
* recipes
 * code coverage (Spanish & French)
 * endpoint testing (Spanish & French)