### PR TITLE
Add a profile script

### DIFF
--- a/.iron-node.js
+++ b/.iron-node.js
@@ -1,0 +1,10 @@
+module.exports = {
+	"app": {
+		"openDevToolsDetached"  : true,  // DEFAULT=FALSE; opens the dev tools windows detached in an own window.
+		"hideMainWindow"        : true,  // DEFAULT=FALSE;  hides the main window to show dev tools only.
+	},
+	"workSpaceDirectory"        : function(argv) {  // determines the workspace directory for specific commandline applications.
+		return __dirname
+	}
+};
+

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// iron-node does not work with forked processes
+// This cli command will run a single file in the current process.
+// Intended to be used with iron-node for profiling purposes.
+
+var path = require('path');
+var meow = require('meow');
+var Promise = require('bluebird');
+var pkgConf = require('pkg-conf');
+var arrify = require('arrify');
+var findCacheDir = require('find-cache-dir');
+var uniqueTempDir = require('unique-temp-dir');
+var EventEmitter = require('events').EventEmitter;
+var CachingPrecompiler = require('./lib/caching-precompiler');
+var globals = require('./lib/globals');
+
+// Chrome gets upset when the `this` value is non-null for these functions.
+globals.setTimeout = setTimeout.bind(null);
+globals.clearTimeout = clearTimeout.bind(null);
+
+Promise.longStackTraces();
+var conf = pkgConf.sync('ava');
+
+// Define a minimal set of options from the main CLI.
+var cli = meow([
+	'usage: iron-node node_modules/ava/profile.js [options] TEST_FILE',
+	'',
+	'Options',
+	'  --fail-fast      Stop after first test failure',
+	'  --serial, -s     Run tests serially',
+	'  --require, -r    Module to preload (Can be repeated)',
+	''
+], {
+	string: [
+		'_',
+		'require'
+	],
+	boolean: [
+		'fail-fast',
+		'verbose',
+		'serial',
+		'tap'
+	],
+	default: conf,
+	alias: {
+		r: 'require',
+		s: 'serial'
+	}
+});
+
+if (cli.input.length !== 1) {
+	throw new Error('no file');
+}
+
+var file = path.resolve(cli.input[0]);
+var cacheDir = findCacheDir({name: 'ava', files: [file]}) || uniqueTempDir();
+var opts = {
+	file: file,
+	failFast: cli.flags.failFast,
+	serial: cli.flags.serial,
+	require: arrify(cli.flags.require),
+	tty: false,
+	cacheDir: cacheDir,
+	precompiled: new CachingPrecompiler(cacheDir).generateHashForFile(file)
+};
+
+var events = new EventEmitter();
+
+// Mock the behavior of a parent process.
+process.send = function (data) {
+	if (data && data.ava) {
+		var name = data.name.replace(/^ava-/, '');
+		if (events.listenerCount(name)) {
+			events.emit(name, data.data);
+		} else {
+			console.log('UNHANDLED AVA EVENT: ', name, data.data);
+		}
+		return;
+	}
+	console.log('NON AVA EVENT: ', data);
+};
+
+events.on('test', function (data) {
+	console.log('TEST:', data.title, data.error);
+});
+
+events.on('results', function (data) {
+	console.log('RESULTS: ', data.stats);
+});
+
+events.on('stats', function () {
+	setImmediate(function () {
+		process.emit('ava-run');
+	});
+});
+
+// test-worker will read process.argv[2] for options
+process.argv[2] = JSON.stringify(opts);
+process.argv.length = 3;
+
+require('./lib/test-worker');


### PR DESCRIPTION
I've been working on getting [`iron-node`](http://s-a.github.io/iron-node/) working with AVA so we can do some proper profiling. I think I finally cracked it.

The first thing was to run in a single process (this means only running a single test file), and fake the response of a parent process. It logs test results to the Chrome DevTools console (and it's not very pretty), but we shouldn't really care about the test results much while profiling.

The second was working around some weirdness with `setTimeout` in `iron-node`. I'm not sure if it's an `iron-node` problem, or an `electron` one, but storing `setTimeout` the way we do in `globals.js` breaks things. The solution here was to just undo our safe copies of `setTimeout` and `clearTimeout`. This means we can't profile against anything that manipulates timers (not sure why that would ever be necessary).