### PR TITLE
Add `match` option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,6 +48,7 @@ var cli = meow([
 	'  --tap, -t        Generate TAP output',
 	'  --verbose, -v    Enable verbose output',
 	'  --no-cache       Disable the transpiler cache',
+	'  --match, -m      Only run tests with titles matching',
 	'',
 	'Examples',
 	'  ava',
@@ -62,7 +63,8 @@ var cli = meow([
 ], {
 	string: [
 		'_',
-		'require'
+		'require',
+		'match'
 	],
 	boolean: [
 		'fail-fast',
@@ -75,7 +77,8 @@ var cli = meow([
 		t: 'tap',
 		v: 'verbose',
 		r: 'require',
-		s: 'serial'
+		s: 'serial',
+		m: 'match'
 	}
 });
 
@@ -90,6 +93,7 @@ var api = new Api(cli.input.length ? cli.input : arrify(conf.files), {
 	failFast: cli.flags.failFast,
 	serial: cli.flags.serial,
 	require: arrify(cli.flags.require),
+	match: cli.flags.match,
 	cacheEnabled: cli.flags.cache !== false
 });
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -27,12 +27,14 @@ var chainableMethods = {
 	}
 };
 
-function Runner() {
+function Runner(opts) {
 	if (!(this instanceof Runner)) {
-		return new Runner();
+		return new Runner(opts);
 	}
 
 	EventEmitter.call(this);
+
+	this.match = (opts && opts.match) ? opts.match : '';
 
 	this.results = [];
 	this.tests = new TestCollection();
@@ -47,6 +49,8 @@ optionChain(chainableMethods, function (opts, title, fn) {
 		fn = title;
 		title = null;
 	}
+
+	opts.skipped = opts.skipped || (title && title.indexOf(this.match) === -1);
 
 	this.tests.add({
 		metadata: opts,

--- a/test/runner.js
+++ b/test/runner.js
@@ -216,3 +216,29 @@ test('only test', function (t) {
 		t.end();
 	});
 });
+
+test('skip test based on match option', function (t) {
+	t.plan(3);
+
+	var runner = new Runner({
+		match: 'dont skip me'
+	});
+
+	runner.test('skip me1', function () {
+		t.fail();
+	});
+
+	runner.skip('skip me2', function () {
+		t.fail();
+	});
+
+	runner.test('dont skip me', function () {
+		t.pass();
+	});
+
+	runner.run().then(function () {
+		t.is(runner.stats.passCount, 1);
+		t.is(runner.stats.failCount, 0);
+		t.end();
+	});
+});


### PR DESCRIPTION
This aims to resolve issue #476. --match can be passed to ava which
means to only run tests with a title matching the provided match
string. The skipped metadata flag will be added to each test not
matching the match string.