### PR TITLE
Consistently require `new` for classes

### DIFF
--- a/api.js
+++ b/api.js
@@ -20,7 +20,7 @@ var CachingPrecompiler = require('./lib/caching-precompiler');
 
 function Api(files, options) {
 	if (!(this instanceof Api)) {
-		return new Api(files, options);
+		throw new TypeError('Class constructor Api cannot be invoked without \'new\'');
 	}
 
 	EventEmitter.call(this);

--- a/lib/ava-error.js
+++ b/lib/ava-error.js
@@ -2,7 +2,7 @@
 
 function AvaError(message) {
 	if (!(this instanceof AvaError)) {
-		return new AvaError(message);
+		throw new TypeError('Class constructor AvaError cannot be invoked without \'new\'');
 	}
 
 	this.message = message;

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -4,7 +4,7 @@ module.exports = Hook;
 
 function Hook(title, fn) {
 	if (!(this instanceof Hook)) {
-		return new Hook(title, fn);
+		throw new TypeError('Class constructor Hook cannot be invoked without \'new\'');
 	}
 
 	if (typeof title === 'function') {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,7 +2,7 @@
 
 function Logger() {
 	if (!(this instanceof Logger)) {
-		return new Logger();
+		throw new TypeError('Class constructor Logger cannot be invoked without \'new\'');
 	}
 
 	Object.keys(Logger.prototype).forEach(function (key) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -29,7 +29,7 @@ var chainableMethods = {
 
 function Runner() {
 	if (!(this instanceof Runner)) {
-		return new Runner();
+		throw new TypeError('Class constructor Runner cannot be invoked without \'new\'');
 	}
 
 	EventEmitter.call(this);

--- a/lib/test.js
+++ b/lib/test.js
@@ -13,7 +13,7 @@ var globals = require('./globals');
 
 function Test(title, fn, contextRef, report) {
 	if (!(this instanceof Test)) {
-		return new Test(title, fn, contextRef, report);
+		throw new TypeError('Class constructor Test cannot be invoked without \'new\'');
 	}
 
 	if (typeof title === 'function') {

--- a/test/observable.js
+++ b/test/observable.js
@@ -1,16 +1,16 @@
 'use strict';
 var test = require('tap').test;
-var _ava = require('../lib/test');
+var Test = require('../lib/test');
 var Observable = require('./fixture/observable');
 
 function ava(fn) {
-	var a = _ava(fn);
+	var a = new Test(fn);
 	a.metadata = {callback: false};
 	return a;
 }
 
 ava.cb = function (fn) {
-	var a = _ava(fn);
+	var a = new Test(fn);
 	a.metadata = {callback: true};
 	return a;
 };

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,16 +1,16 @@
 'use strict';
 var Promise = require('bluebird');
 var test = require('tap').test;
-var _ava = require('../lib/test');
+var Test = require('../lib/test');
 
 function ava(fn) {
-	var a = _ava(fn);
+	var a = new Test(fn);
 	a.metadata = {callback: false};
 	return a;
 }
 
 ava.cb = function (fn) {
-	var a = _ava(fn);
+	var a = new Test(fn);
 	a.metadata = {callback: true};
 	return a;
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,15 +1,8 @@
 'use strict';
 var test = require('tap').test;
-var runner = require('../lib/runner');
-// var Test = require('../lib/test');
-var Runner = runner;
-// var mockTitle = 'mock title';
-var noop = function () {};
+var Runner = require('../lib/runner');
 
-test('returns new instance of runner without "new"', function (t) {
-	t.ok(runner({}) instanceof runner);
-	t.end();
-});
+var noop = function () {};
 
 test('runner emits a "test" event', function (t) {
 	var runner = new Runner();

--- a/test/test.js
+++ b/test/test.js
@@ -3,16 +3,16 @@ var test = require('tap').test;
 var Promise = global.Promise = require('bluebird');
 var delay = require('delay');
 var isPromise = require('is-promise');
-var _ava = require('../lib/test');
+var Test = require('../lib/test');
 
-function ava() {
-	var t = _ava.apply(null, arguments);
+function ava(title, fn, contextRef, report) {
+	var t = new Test(title, fn, contextRef, report);
 	t.metadata = {callback: false};
 	return t;
 }
 
-ava.cb = function () {
-	var t = _ava.apply(null, arguments);
+ava.cb = function (title, fn, contextRef, report) {
+	var t = new Test(title, fn, contextRef, report);
 	t.metadata = {callback: true};
 	return t;
 };
@@ -513,7 +513,7 @@ test('assertions return promises', function (t) {
 });
 
 test('contextRef', function (t) {
-	new _ava('foo',
+	new Test('foo',
 		function (a) {
 			t.same(a.context, {foo: 'bar'});
 			t.end();


### PR DESCRIPTION
To be forward compatible with ES2015 classes.