### PR TITLE
Shorten the plan stack.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -77,7 +77,7 @@ Test.prototype._setAssertError = function (err) {
 	this.assertError = err;
 };
 
-Test.prototype.plan = function (count) {
+Test.prototype.plan = function (count, planStack) {
 	if (typeof count !== 'number') {
 		throw new TypeError('Expected a number');
 	}
@@ -86,7 +86,7 @@ Test.prototype.plan = function (count) {
 
 	// in case the `planCount` doesn't match `assertCount,
 	// we need the stack of this function to throw with a useful stack
-	this.planStack = new Error().stack;
+	this.planStack = planStack;
 };
 
 Test.prototype._run = function () {
@@ -265,7 +265,6 @@ Test.prototype._publicApi = function () {
 
 function PublicApi(test) {
 	this._test = test;
-	this.plan = test.plan.bind(test);
 	this.skip = new SkipApi(test);
 }
 
@@ -302,6 +301,15 @@ PublicApi.prototype = enhanceAssert({
 	onSuccess: onAssertionEvent,
 	onError: onAssertionEvent
 });
+
+PublicApi.prototype.plan = function plan(ct) {
+	var limitBefore = Error.stackTraceLimit;
+	Error.stackTraceLimit = 1;
+	var obj = {};
+	Error.captureStackTrace(obj, plan);
+	Error.stackTraceLimit = limitBefore;
+	this._test.plan(ct, obj.stack);
+};
 
 // Getters
 [


### PR DESCRIPTION
Every call to `t.plan` generates a stack trace. Apparently those stack traces are expensive. This speeds things up by shortening the stack trace.

I am not sure we need more than a depth of 1.

benchmark:

```js
import test from 'ava';

for (var i = 0; i < 10000; i++) {
	test(`test${i}`, t => {
		t.plan(1);
		t.pass();
	});
}
```


master:

```
node cli.js test/lots-of-plans.js --verbose  6.16s user 0.58s system 119% cpu 5.647 total
```

depth 1 (current value in this PR):

```
node cli.js test/lots-of-plans.js --verbose  2.43s user 0.48s system 142% cpu 2.044 total
```

depth of 2:

```
node cli.js test/lots-of-plans.js --verbose  2.66s user 0.42s system 128% cpu 2.392 total
```

depth of 3: 

```
node cli.js test/lots-of-plans.js --verbose  3.04s user 0.49s system 133% cpu 2.648 total
```

depth of 4:

```
node cli.js test/lots-of-plans.js --verbose  3.24s user 0.50s system 131% cpu 2.850 total
```