### PR TITLE
add `.regex()` assertion method

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -122,8 +122,8 @@ x.doesNotThrow = function (fn, msg) {
 	}
 };
 
-x.regexTest = function (regex, contents, msg) {
-	test(regex.test(contents), create(regex, contents, '===', msg, x.regexTest));
+x.regex = function (contents, regex, msg) {
+	test(regex.test(contents), create(regex, contents, '===', msg, x.regex));
 };
 
 x.ifError = x.error = function (err, msg) {

--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -10,7 +10,7 @@ module.exports.PATTERNS = [
 	't.not(value, expected, [message])',
 	't.same(value, expected, [message])',
 	't.notSame(value, expected, [message])',
-	't.regexTest(regex, contents, [message])'
+	't.regex(contents, regex, [message])'
 ];
 
 module.exports.NON_ENHANCED_PATTERNS = [

--- a/readme.md
+++ b/readme.md
@@ -594,6 +594,10 @@ Assert that `function` throws an error or `promise` rejects.
 
 Assert that `function` doesn't throw an `error` or `promise` resolves.
 
+### .regex(contents, regex, [message])
+
+Assert that `contents` matches `regex`.
+
 ### .ifError(error, [message])
 
 Assert that `error` is falsy.

--- a/test/assert.js
+++ b/test/assert.js
@@ -196,13 +196,13 @@ test('.doesNotThrow()', function (t) {
 	t.end();
 });
 
-test('.regexTest()', function (t) {
+test('.regex()', function (t) {
 	t.doesNotThrow(function () {
-		assert.regexTest(/^abc$/, 'abc');
+		assert.regex('abc', /^abc$/);
 	});
 
 	t.throws(function () {
-		assert.regexTest(/^abc$/, 'foo');
+		assert.regex('foo', /^abc$/);
 	});
 
 	t.end();


### PR DESCRIPTION
Reimplementation of `.regexTest()`, with arguments flipped. The new order aligns with that of the other assertions available on the test context. 

Ref issue; #142 