### PR TITLE
Fix skip count not reporting properly

### DIFF
--- a/api.js
+++ b/api.js
@@ -30,6 +30,7 @@ function Api(files, options) {
 	this.rejectionCount = 0;
 	this.exceptionCount = 0;
 	this.passCount = 0;
+	this.skipCount = 0;
 	this.failCount = 0;
 	this.fileCount = 0;
 	this.testCount = 0;
@@ -204,6 +205,7 @@ Api.prototype.run = function () {
 			self.tests = flatten(self.tests);
 
 			self.passCount = sum(self.stats, 'passCount');
+			self.skipCount = sum(self.stats, 'skipCount');
 			self.failCount = sum(self.stats, 'failCount');
 		});
 };

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -62,10 +62,11 @@ TapReporter.prototype.unhandledError = function (err) {
 };
 
 TapReporter.prototype.finish = function () {
+	// console.log(this.api)
 	var output = [
 		'',
-		'1..' + (this.api.passCount + this.api.failCount),
-		'# tests ' + (this.api.passCount + this.api.failCount),
+		'1..' + (this.api.passCount + this.api.failCount + this.api.skipCount),
+		'# tests ' + (this.api.passCount + this.api.failCount + this.api.skipCount),
 		'# pass ' + this.api.passCount
 	];
 

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -91,8 +91,8 @@ test('results', function (t) {
 	var actualOutput = reporter.finish();
 	var expectedOutput = [
 		'',
-		'1..' + (api.passCount + api.failCount),
-		'# tests ' + (api.passCount + api.failCount),
+		'1..' + (api.passCount + api.failCount + api.skipCount),
+		'# tests ' + (api.passCount + api.failCount + api.skipCount),
 		'# pass ' + api.passCount,
 		'# skip ' + api.skipCount,
 		'# fail ' + (api.failCount + api.rejectionCount + api.exceptionCount),


### PR DESCRIPTION
This fixes #470.

What was happening was that the API did not have a `skipCount` property, so the TAP reporter had nothing to report with. This commit adds it to the API and then updates the TAP reporter so it can use it.

[Seems to work](http://i.imgur.com/YSzK1cY.png), but could use more pairs of eyes.