### PR TITLE
Add david-dm.org badges in `maintaining.md`.

### DIFF
--- a/maintaining.md
+++ b/maintaining.md
@@ -1,4 +1,4 @@
-# Maintaining
+# Maintaining [![Dependency Status](https://david-dm.org/sindresorhus/ava.svg)](https://david-dm.org/sindresorhus/ava) [![devDependency Status](https://david-dm.org/sindresorhus/ava/dev-status.svg)](https://david-dm.org/sindresorhus/ava#info=devDependencies)
 
 
 ## Testing


### PR DESCRIPTION
I added these to the `maintaining.md` so they don't clutter the top of the Readme.

Handles the first step of the Release process at a glance.