### PR TITLE
Return empty string instead of null for a single anonymous test

### DIFF
--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -27,7 +27,7 @@ VerboseReporter.prototype.test = function (test) {
 	}
 
 	if (this.api.fileCount === 1 && this.api.testCount === 1 && test.title === '[anonymous]') {
-		return '';
+		return undefined;
 	}
 
 	// display duration only over a threshold

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -27,7 +27,7 @@ VerboseReporter.prototype.test = function (test) {
 	}
 
 	if (this.api.fileCount === 1 && this.api.testCount === 1 && test.title === '[anonymous]') {
-		return null;
+		return '';
 	}
 
 	// display duration only over a threshold

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -70,7 +70,7 @@ test('don\'t display test title if there is only one anonymous test', function (
 		title: '[anonymous]'
 	});
 
-	t.is(output, null);
+	t.is(output, '');
 	t.end();
 });
 

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -70,7 +70,7 @@ test('don\'t display test title if there is only one anonymous test', function (
 		title: '[anonymous]'
 	});
 
-	t.is(output, '');
+	t.is(output, undefined);
 	t.end();
 });
 


### PR DESCRIPTION
This fixes #487 by returning an empty string instead of `null` when there's just one anonymous test. This also keeps the behavior of printing `[anonymous]` when there are more than one anonymous tests.