### PR TITLE
`t.doesNotThrow` → `t.notThrows`

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -4,6 +4,7 @@ var deepEqual = require('deeper');
 var observableToPromise = require('observable-to-promise');
 var isObservable = require('is-observable');
 var isPromise = require('is-promise');
+var util = require('util');
 var x = module.exports;
 
 Object.defineProperty(x, 'AssertionError', {value: assert.AssertionError});
@@ -122,7 +123,7 @@ x.notThrows = function (fn, msg) {
 	}
 };
 
-x.doesNotThrow = x.notThrows;
+x.doesNotThrow = util.deprecate(x.notThrows, 't.doesNotThrow is renamed to t.notThrows. The old name still works, but will be removed in AVA 1.0.0. Update your references.');
 
 x.regex = function (contents, regex, msg) {
 	test(regex.test(contents), create(regex, contents, '===', msg, x.regex));

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -110,7 +110,7 @@ x.notThrows = function (fn, msg) {
 	if (isPromise(fn)) {
 		return fn
 			.catch(function (err) {
-				x.doesNotThrow(function () {
+				x.notThrows(function () {
 					throw err;
 				}, msg);
 			});

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -101,7 +101,7 @@ x.throws = function (fn, err, msg) {
 	}
 };
 
-x.doesNotThrow = function (fn, msg) {
+x.notThrows = function (fn, msg) {
 	if (isObservable(fn)) {
 		fn = observableToPromise(fn);
 	}
@@ -118,9 +118,11 @@ x.doesNotThrow = function (fn, msg) {
 	try {
 		assert.doesNotThrow(fn, msg);
 	} catch (err) {
-		test(false, create(err.actual, err.expected, err.operator, err.message, x.doesNotThrow));
+		test(false, create(err.actual, err.expected, err.operator, err.message, x.notThrows));
 	}
 };
+
+x.doesNotThrow = x.notThrows;
 
 x.regex = function (contents, regex, msg) {
 	test(regex.test(contents), create(regex, contents, '===', msg, x.regex));

--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -17,7 +17,7 @@ module.exports.NON_ENHANCED_PATTERNS = [
 	't.pass([message])',
 	't.fail([message])',
 	't.throws(fn, [message])',
-	't.doesNotThrow(fn, [message])',
+	't.notThrows(fn, [message])',
 	't.ifError(error, [message])'
 ];
 

--- a/readme.md
+++ b/readme.md
@@ -590,7 +590,7 @@ Assert that `function` throws an error or `promise` rejects.
 
 `error` can be a constructor, regex, error message or validation function.
 
-### .doesNotThrow(function|promise, [message])
+### .notThrows(function|promise, [message])
 
 Assert that `function` doesn't throw an `error` or `promise` resolves.
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -182,7 +182,21 @@ test('.throws()', function (t) {
 	t.end();
 });
 
-test('.doesNotThrow()', function (t) {
+test('.notThrows()', function (t) {
+	t.doesNotThrow(function () {
+		assert.notThrows(function () {});
+	});
+
+	t.throws(function () {
+		assert.notThrows(function () {
+			throw new Error('foo');
+		});
+	});
+
+	t.end();
+});
+
+test('.doesNotThrow() alias for .notThrows()', function (t) {
 	t.doesNotThrow(function () {
 		assert.doesNotThrow(function () {});
 	});

--- a/test/observable.js
+++ b/test/observable.js
@@ -131,12 +131,12 @@ test('handle throws with false-positive observable', function (t) {
 	});
 });
 
-test('handle doesNotThrow with completed observable', function (t) {
+test('handle notThrows with completed observable', function (t) {
 	ava(function (a) {
 		a.plan(1);
 
 		var observable = Observable.of();
-		return a.doesNotThrow(observable);
+		return a.notThrows(observable);
 	}).run().then(function (result) {
 		t.is(result.passed, true);
 		t.is(result.result.assertCount, 1);
@@ -144,7 +144,7 @@ test('handle doesNotThrow with completed observable', function (t) {
 	});
 });
 
-test('handle doesNotThrow with thrown observable', function (t) {
+test('handle notThrows with thrown observable', function (t) {
 	ava(function (a) {
 		a.plan(1);
 
@@ -152,7 +152,7 @@ test('handle doesNotThrow with thrown observable', function (t) {
 			observer.error(new Error());
 		});
 
-		return a.doesNotThrow(observable);
+		return a.notThrows(observable);
 	}).run().then(function (result) {
 		t.is(result.passed, false);
 		t.is(result.reason.name, 'AssertionError');

--- a/test/promise.js
+++ b/test/promise.js
@@ -249,12 +249,12 @@ test('handle throws with false-positive promise', function (t) {
 	});
 });
 
-test('handle doesNotThrow with resolved promise', function (t) {
+test('handle notThrows with resolved promise', function (t) {
 	ava(function (a) {
 		a.plan(1);
 
 		var promise = Promise.resolve();
-		return a.doesNotThrow(promise);
+		return a.notThrows(promise);
 	}).run().then(function (result) {
 		t.is(result.passed, true);
 		t.is(result.result.assertCount, 1);
@@ -262,12 +262,12 @@ test('handle doesNotThrow with resolved promise', function (t) {
 	});
 });
 
-test('handle doesNotThrow with rejected promise', function (t) {
+test('handle notThrows with rejected promise', function (t) {
 	ava(function (a) {
 		a.plan(1);
 
 		var promise = Promise.reject(new Error());
-		return a.doesNotThrow(promise);
+		return a.notThrows(promise);
 	}).run().then(function (result) {
 		t.is(result.passed, false);
 		t.is(result.reason.name, 'AssertionError');

--- a/test/test.js
+++ b/test/test.js
@@ -207,9 +207,9 @@ test('handle throws without error', function (t) {
 	t.end();
 });
 
-test('handle doesNotThrow with error', function (t) {
+test('handle notThrows with error', function (t) {
 	var result = ava(function (a) {
-		a.doesNotThrow(function () {
+		a.notThrows(function () {
 			throw new Error('foo');
 		});
 	}).run();
@@ -220,9 +220,9 @@ test('handle doesNotThrow with error', function (t) {
 	t.end();
 });
 
-test('handle doesNotThrow without error', function (t) {
+test('handle notThrows without error', function (t) {
 	var result = ava(function (a) {
-		a.doesNotThrow(function () {
+		a.notThrows(function () {
 			return;
 		});
 	}).run();
@@ -383,12 +383,12 @@ test('skipped assertions count towards the plan', function (t) {
 	t.end();
 });
 
-test('throws and doesNotThrow work with promises', function (t) {
+test('throws and notThrows work with promises', function (t) {
 	var asyncCalled = false;
 	ava(function (a) {
 		a.plan(2);
 		a.throws(delay.reject(10, new Error('foo')), 'foo');
-		a.doesNotThrow(delay(20).then(function () {
+		a.notThrows(delay(20).then(function () {
 			asyncCalled = true;
 		}));
 	}).run().then(function (result) {
@@ -403,7 +403,7 @@ test('throws and doesNotThrow work with promises', function (t) {
 test('waits for t.throws to resolve after t.end is called', function (t) {
 	ava.cb(function (a) {
 		a.plan(1);
-		a.doesNotThrow(delay(10), 'foo');
+		a.notThrows(delay(10), 'foo');
 		a.end();
 	}).run().then(function (result) {
 		t.is(result.passed, true);
@@ -429,7 +429,7 @@ test('waits for t.throws to reject after t.end is called', function (t) {
 test('waits for t.throws to resolve after the promise returned from the test resolves', function (t) {
 	ava(function (a) {
 		a.plan(1);
-		a.doesNotThrow(delay(10), 'foo');
+		a.notThrows(delay(10), 'foo');
 		return Promise.resolve();
 	}).run().then(function (result) {
 		t.is(result.passed, true);
@@ -452,12 +452,12 @@ test('waits for t.throws to reject after the promise returned from the test reso
 	});
 });
 
-test('multiple resolving and rejecting promises passed to t.throws/t.doesNotThrow', function (t) {
+test('multiple resolving and rejecting promises passed to t.throws/t.notThrows', function (t) {
 	ava(function (a) {
 		a.plan(6);
 		for (var i = 0; i < 3; ++i) {
 			a.throws(delay.reject(10, new Error('foo')), 'foo');
-			a.doesNotThrow(delay(10), 'foo');
+			a.notThrows(delay(10), 'foo');
 		}
 	}).run().then(function (result) {
 		t.is(result.passed, true);
@@ -471,7 +471,7 @@ test('number of assertions matches t.plan when the test exits, but before all pr
 	ava(function (a) {
 		a.plan(2);
 		a.throws(delay.reject(10, new Error('foo')), 'foo');
-		a.doesNotThrow(delay(10), 'foo');
+		a.notThrows(delay(10), 'foo');
 		setTimeout(function () {
 			a.throws(Promise.reject(new Error('foo')), 'foo');
 		}, 5);
@@ -488,7 +488,7 @@ test('number of assertions doesn\'t match plan when the test exits, but before a
 	ava(function (a) {
 		a.plan(3);
 		a.throws(delay.reject(10, new Error('foo')), 'foo');
-		a.doesNotThrow(delay(10), 'foo');
+		a.notThrows(delay(10), 'foo');
 		setTimeout(function () {
 			a.throws(Promise.reject(new Error('foo')), 'foo');
 		}, 5);
@@ -505,7 +505,7 @@ test('assertions return promises', function (t) {
 	ava(function (a) {
 		a.plan(2);
 		t.ok(isPromise(a.throws(Promise.reject(new Error('foo')))));
-		t.ok(isPromise(a.doesNotThrow(Promise.resolve(true))));
+		t.ok(isPromise(a.notThrows(Promise.resolve(true))));
 	}).run().then(function (result) {
 		t.is(result.passed, true);
 		t.end();


### PR DESCRIPTION
This helps with #507 by renaming `t.doesNotThrow` to `t.notThrows`, updating tests and documentation, and adding a `t.doesNotThrow` alias for backwards compatibility.