### PR TITLE
fix beautify stack split error - fixes #509

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "serialize-error": "^1.1.0",
     "set-immediate-shim": "^1.0.1",
     "source-map-support": "^0.4.0",
-    "stack-utils": "^0.3.0",
+    "stack-utils": "^0.4.0",
     "strip-bom": "^2.0.0",
     "time-require": "^0.1.2",
     "unique-temp-dir": "^1.0.0",


### PR DESCRIPTION
This tiny PR fixes #509 and #459 when `beautifyStack` returns `null`.