### PR TITLE
Add empty line before output to mini reporter

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -66,7 +66,7 @@ MiniReporter.prototype.unhandledError = function (err) {
 };
 
 MiniReporter.prototype.finish = function () {
-	var status = '';
+	var status = '\n';
 
 	if (this.passCount > 0) {
 		status += '  ' + colors.pass(this.passCount, 'passed');

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -75,7 +75,7 @@ test('results with passing tests', function (t) {
 
 	var actualOutput = reporter.finish();
 	var expectedOutput = [
-		'  ' + chalk.green('1 passed'),
+		'\n  ' + chalk.green('1 passed'),
 		''
 	].join('\n');
 
@@ -91,7 +91,7 @@ test('results with skipped tests', function (t) {
 
 	var actualOutput = reporter.finish();
 	var expectedOutput = [
-		'  ' + chalk.yellow('1 skipped'),
+		'\n  ' + chalk.yellow('1 skipped'),
 		''
 	].join('\n');
 
@@ -106,8 +106,9 @@ test('results with passing skipped tests', function (t) {
 
 	var output = reporter.finish().split('\n');
 
-	t.is(output[0], '  ' + chalk.green('1 passed') + '  ' + chalk.yellow('1 skipped'));
-	t.is(output[1], '');
+	t.is(output[0], '');
+	t.is(output[1], '  ' + chalk.green('1 passed') + '  ' + chalk.yellow('1 skipped'));
+	t.is(output[2], '');
 	t.end();
 });
 
@@ -126,12 +127,13 @@ test('results with passing tests and rejections', function (t) {
 
 	var output = reporter.finish().split('\n');
 
-	t.is(output[0], '  ' + chalk.green('1 passed'));
-	t.is(output[1], '  ' + chalk.red('1 rejection'));
-	t.is(output[2], '');
-	t.is(output[3], '  ' + chalk.red('1. Unhandled Rejection'));
-	t.match(output[4], /Error: failure/);
-	t.match(output[5], /test\/reporters\/mini\.js/);
+	t.is(output[0], '');
+	t.is(output[1], '  ' + chalk.green('1 passed'));
+	t.is(output[2], '  ' + chalk.red('1 rejection'));
+	t.is(output[3], '');
+	t.is(output[4], '  ' + chalk.red('1. Unhandled Rejection'));
+	t.match(output[5], /Error: failure/);
+	t.match(output[6], /test\/reporters\/mini\.js/);
 	t.end();
 });
 
@@ -150,12 +152,13 @@ test('results with passing tests and exceptions', function (t) {
 
 	var output = reporter.finish().split('\n');
 
-	t.is(output[0], '  ' + chalk.green('1 passed'));
-	t.is(output[1], '  ' + chalk.red('1 exception'));
-	t.is(output[2], '');
-	t.is(output[3], '  ' + chalk.red('1. Uncaught Exception'));
-	t.match(output[4], /Error: failure/);
-	t.match(output[5], /test\/reporters\/mini\.js/);
+	t.is(output[0], '');
+	t.is(output[1], '  ' + chalk.green('1 passed'));
+	t.is(output[2], '  ' + chalk.red('1 exception'));
+	t.is(output[3], '');
+	t.is(output[4], '  ' + chalk.red('1. Uncaught Exception'));
+	t.match(output[5], /Error: failure/);
+	t.match(output[6], /test\/reporters\/mini\.js/);
 	t.end();
 });
 
@@ -175,11 +178,12 @@ test('results with errors', function (t) {
 
 	var output = reporter.finish().split('\n');
 
-	t.is(output[0], '  ' + chalk.red('1 failed'));
-	t.is(output[1], '');
-	t.is(output[2], '  ' + chalk.red('1. failed'));
-	t.match(output[3], /failure/);
-	t.match(output[4], /Error: failure/);
-	t.match(output[5], /test\/reporters\/mini\.js/);
+	t.is(output[0], '');
+	t.is(output[1], '  ' + chalk.red('1 failed'));
+	t.is(output[2], '');
+	t.is(output[3], '  ' + chalk.red('1. failed'));
+	t.match(output[4], /failure/);
+	t.match(output[5], /Error: failure/);
+	t.match(output[6], /test\/reporters\/mini\.js/);
 	t.end();
 });


### PR DESCRIPTION
This fixe #479 by adding a `\n` to the output of the mini reporter and updating the current tests so they pass.