### PR TITLE
[WIP] Set `cwd` of forks to parent `process.cwd()`

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -17,7 +17,7 @@ module.exports = function (file, opts) {
 	}, opts);
 
 	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
-		cwd: path.dirname(file),
+		cwd: process.cwd(),
 		silent: true
 	});
 


### PR DESCRIPTION
Fixes #515. On my machine there are 31 failing tests (I also had 31 failing tests on master)