### PR TITLE
Removed warning for handle-callback-err

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -84,6 +84,7 @@ test('throwing a anonymous function will report the function to the console', fu
 
 test('log failed tests', function (t) {
 	execCli('fixture/one-pass-one-fail.js', function (err, stdout, stderr) {
+		t.ok(err);
 		t.match(stderr, /AssertionError: false == true/);
 		t.end();
 	});


### PR DESCRIPTION
Removed the warning we are getting when running npm test for test/cli.js.

The warning was:

86:42 warning Expected error to be handled  handle-callback-err