### PR TITLE
Clarifies `npm test` default file is `test.js`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,8 @@ Install AVA globally `$ npm install --global ava` and run `$ ava --init` (with a
 
 #### Create your test file
 
+Create a file named `test.js` in the project root directory.
+
 ```js
 import test from 'ava';
 import delay from 'delay';
@@ -94,9 +96,8 @@ test('bar', async t => {
 #### Run it
 
 ```
-$ npm test
+$ npm test 
 ```
-
 
 ## CLI
 


### PR DESCRIPTION
I'm using AVA for the first time.

Following the Usage section of readme.md it isn't clear that the default test file is `./test.js`. This pull request clarifies the default usage. 