### PR TITLE
Removed redundant line from assertion error output in mini reporter

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -106,7 +106,7 @@ MiniReporter.prototype.finish = function () {
 			var description;
 
 			if (test.error) {
-				description = '  ' + test.error.message + '\n  ' + test.error.stack;
+				description = '  ' + test.error.message + '\n  ' + stripFirstLine(test.error.stack);
 			} else {
 				description = JSON.stringify(test);
 			}
@@ -218,4 +218,8 @@ function eraseLines(count) {
 	}
 
 	return clear;
+}
+
+function stripFirstLine(message) {
+	return message.replace(/^[^\n]*\n/, '');
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -92,7 +92,7 @@ test('throwing a anonymous function will report the function to the console', fu
 test('log failed tests', function (t) {
 	execCli('fixture/one-pass-one-fail.js', function (err, stdout, stderr) {
 		t.ok(err);
-		t.match(stderr, /AssertionError: false == true/);
+		t.match(stderr, /false == true/);
 		t.end();
 	});
 });

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -189,8 +189,7 @@ test('results with errors', function (t) {
 	t.is(output[2], '');
 	t.is(output[3], '  ' + chalk.red('1. failed'));
 	t.match(output[4], /failure/);
-	t.match(output[5], /Error: failure/);
-	t.match(output[6], /test\/reporters\/mini\.js/);
+	t.match(output[5], /test\/reporters\/mini\.js/);
 	t.end();
 });
 


### PR DESCRIPTION
Fixes #422. Removed the `AssertionError: ...` line of output.