### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,7 +131,7 @@ export interface TestContext extends AssertContext {
 	 */
 	plan(count: number): void;
 
-	skip: TestContext;
+	skip: AssertContext;
 }
 export interface CallbackTestContext extends TestContext {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,141 @@
+export interface Observable {
+	subscribe(observer: (value: {}) => void): void;
+}
+
+export type Test = (t: TestContext) => Promise<void> | Iterator<any> | Observable | void;
+export type SerialTest = (t: TestContext) => void;
+export type CallbackTest = (t: CallbackTestContext) => void;
+
+export interface Runner {
+	(name: string, run: Test): void;
+	(run: Test): void;
+	skip: Runner;
+	cb: CallbackRunner;
+}
+export interface SerialRunner {
+	(name: string, run: SerialTest): void;
+	(run: SerialTest): void;
+	skip: SerialRunner;
+}
+export interface CallbackRunner {
+	(name: string, run: CallbackTest): void;
+	(run: CallbackTest): void;
+	skip: CallbackRunner;
+}
+
+export function test(name: string, run: Test): void;
+export function test(run: Test): void;
+export namespace test {
+	export const before: Runner;
+	export const after: Runner;
+	export const beforeEach: Runner;
+	export const afterEach: Runner;
+
+	export const skip: typeof test;
+	export const only: typeof test;
+
+	export function serial(name: string, run: SerialTest): void;
+	export function serial(run: SerialTest): void;
+	export function cb(name: string, run: CallbackTest): void;
+	export function cb(run: CallbackTest): void;
+}
+export namespace test.serial {
+	export const before: SerialRunner;
+	export const after: SerialRunner;
+	export const beforeEach: SerialRunner;
+	export const afterEach: SerialRunner;
+
+	export const skip: typeof test.serial;
+	export const only: typeof test.serial;
+}
+export namespace test.cb {
+	export const before: CallbackRunner;
+	export const after: CallbackRunner;
+	export const beforeEach: CallbackRunner;
+	export const afterEach: CallbackRunner;
+
+	export const skip: typeof test.cb;
+	export const only: typeof test.cb;
+}
+export default test;
+
+export type ErrorValidator
+	= (new (...args: any[]) => any)
+	| RegExp
+	| string
+	| ((error: any) => boolean);
+
+export interface AssertContext {
+	/**
+	 * Passing assertion.
+	 */
+	pass(message?: string): void;
+	/**
+	 * Failing assertion.
+	 */
+	fail(message?: string): void;
+	/**
+	 * Assert that value is truthy.
+	 */
+	ok(value: any, message?: string): void;
+	/**
+	 * Assert that value is falsy.
+	 */
+	notOk(value: any, message?: string): void;
+	/**
+	 * Assert that value is true.
+	 */
+	true(value: boolean, message?: string): void;
+	/**
+	 * Assert that value is false.
+	 */
+	false(value: boolean, message?: string): void;
+	/**
+	 * Assert that value is equal to expected.
+	 */
+	is<U>(value: U, expected: U, message?: string): void;
+	/**
+	 * Assert that value is not equal to expected.
+	 */
+	not<U>(value: U, expected: U, message?: string): void;
+	/**
+	 * Assert that value is deep equal to expected.
+	 */
+	same<U>(value: U, expected: U, message?: string): void;
+	/**
+	 * Assert that value is not deep equal to expected.
+	 */
+	notSame<U>(value: U, expected: U, message?: string): void;
+	/**
+	 * Assert that function throws an error or promise rejects.
+	 * @param error Can be a constructor, regex, error message or validation function.
+	 */
+	throws(value: (() => void) | Promise<{}>, error?: ErrorValidator, message?: string);
+	/**
+	 * Assert that function doesn't throw an error or promise resolves.
+	 */
+	notThrows(value: (() => void) | Promise<{}>, message?: string);
+	/**
+	 * Assert that contents matches regex.
+	 */
+	regex(contents: string, regex: RegExp, message?: string): void;
+	/**
+	 * Assert that error is falsy.
+	 */
+	ifError(error: any, message?: string): void;
+}
+export interface TestContext extends AssertContext {
+	/**
+	 * Plan how many assertion there are in the test.
+	 * The test will fail if the actual assertion count doesn't match planned assertions.
+	 */
+	plan(count: number): void;
+
+	skip: TestContext;
+}
+export interface CallbackTestContext extends TestContext {
+	/**
+	 * End the test.
+	 */
+	end(): void;
+}

--- a/index.js
+++ b/index.js
@@ -90,5 +90,5 @@ globals.setImmediate(function () {
 
 module.exports = runner.test;
 // TypeScript imports the `default` property for
-// an ES6 default import (`import test from 'ava'`)
+// an ES2015 default import (`import test from 'ava'`)
 module.exports.default = runner.test;

--- a/index.js
+++ b/index.js
@@ -91,4 +91,5 @@ globals.setImmediate(function () {
 module.exports = runner.test;
 // TypeScript imports the `default` property for
 // an ES2015 default import (`import test from 'ava'`)
+// See: https://github.com/Microsoft/TypeScript/issues/2242#issuecomment-83694181
 module.exports.default = runner.test;

--- a/index.js
+++ b/index.js
@@ -89,3 +89,6 @@ globals.setImmediate(function () {
 });
 
 module.exports = runner.test;
+// TypeScript imports the `default` property for
+// an ES6 default import (`import test from 'ava'`)
+module.exports.default = runner.test;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "files": [
     "lib",
-    "*.js"
+    "*.js",
+	"index.d.ts"
   ],
   "keywords": [
     "test",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "files": [
     "lib",
     "*.js",
-	"index.d.ts"
+    "index.d.ts"
   ],
   "keywords": [
     "test",

--- a/readme.md
+++ b/readme.md
@@ -363,6 +363,10 @@ test(t => {
 
 AVA comes with builtin support for ES2015 through [Babel 6](https://babeljs.io). Just write your tests in ES2015. No extra setup needed. You can use any Babel version in your project. We use our own bundled Babel with the [`es2015`](http://babeljs.io/docs/plugins/preset-es2015/) and [`stage-2`](http://babeljs.io/docs/plugins/preset-stage-2/) presets.
 
+### TypeScript support
+
+AVA includes typings for TypeScript. You have to setup transpilation yourself. When you set `module` to `commonjs`, TypeScript will automatically find the type definitions for AVA. You should set `target` to `es2015` to use Promises and async functions.
+
 #### Transpiling Imported Modules
 
 AVA currently only transpiles the tests you ask it to run. *It will not transpile modules you ```import``` from outside of the test.* While there are valid reasons for taking this approach, it may not be what you expect!

--- a/readme.md
+++ b/readme.md
@@ -365,7 +365,7 @@ AVA comes with builtin support for ES2015 through [Babel 6](https://babeljs.io).
 
 ### TypeScript support
 
-AVA includes typings for TypeScript. You have to setup transpilation yourself. When you set `module` to `commonjs`, TypeScript will automatically find the type definitions for AVA. You should set `target` to `es2015` to use Promises and async functions.
+AVA includes typings for TypeScript. You have to setup transpilation yourself. When you set `module` to `commonjs` in your `tsconfig.json` file, TypeScript will automatically find the type definitions for AVA. You should set `target` to `es2015` to use Promises and async functions.
 
 #### Transpiling Imported Modules
 


### PR DESCRIPTION
I've added type definitions for TypeScript users. The exact same code from the readme can be used in TypeScript without type errors. JavaScript programmers, using VSCode, can also get better completions with these typings.

Ping me when you update the API and I will update these typings.

Fixes #568