### PR TITLE
Added support for babel config under package.json/ava key (Fixes #448)

### DIFF
--- a/api.js
+++ b/api.js
@@ -187,7 +187,7 @@ Api.prototype.run = function (files) {
 				uniqueTempDir();
 
 			self.options.cacheDir = cacheDir;
-			self.precompiler = new CachingPrecompiler(cacheDir);
+			self.precompiler = new CachingPrecompiler(cacheDir, self.options.babelConfig);
 			self.fileCount = files.length;
 			self.base = path.relative('.', commonPathPrefix(files)) + path.sep;
 

--- a/cli.js
+++ b/cli.js
@@ -35,7 +35,11 @@ var Api = require('./api');
 // Bluebird specific
 Promise.longStackTraces();
 
-var conf = pkgConf.sync('ava');
+var conf = pkgConf.sync('ava', {
+	defaults: {
+		babel: 'default'
+	}
+});
 
 var cli = meow([
 	'Usage',

--- a/cli.js
+++ b/cli.js
@@ -102,7 +102,8 @@ var api = new Api({
 	require: arrify(cli.flags.require),
 	cacheEnabled: cli.flags.cache !== false,
 	explicitTitles: cli.flags.watch,
-	match: arrify(cli.flags.match)
+	match: arrify(cli.flags.match),
+	babelConfig: conf.babel
 });
 
 var reporter;

--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -31,26 +31,27 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 		// Extract existing source maps from the code.
 		var sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename));
 
-		var baseOptions = {
+		var options = {babelrc: false};
+
+		if (babelConfig === 'default') {
+			objectAssign(options, {presets: [presetStage2, presetES2015]});
+		} else if (babelConfig === 'inherit') {
+			objectAssign(options, {babelrc: true});
+		} else {
+			objectAssign(options, babelConfig);
+		}
+
+		objectAssign(options, {
+			inputSourceMap: sourceMap && sourceMap.toObject(),
 			filename: filename,
 			sourceMaps: true,
-			ast: false,
-			inputSourceMap: sourceMap && sourceMap.toObject(),
-			babelrc: false
-		};
+			ast: false
+		});
 
-		if (!babelConfig || babelConfig === 'default') {
-			return objectAssign({}, baseOptions, {
-				presets: [presetStage2, presetES2015],
-				plugins: [powerAssert, transformRuntime]
-			});
-		}
+		options.plugins = options.plugins || [];
+		options.plugins.push(powerAssert, transformRuntime);
 
-		if (babelConfig === 'inherit') {
-			return objectAssign({}, baseOptions, {babelrc: true});
-		}
-
-		return objectAssign({}, baseOptions, babelConfig);
+		return options;
 	}
 
 	return function (code, filename, hash) {

--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -33,7 +33,7 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 
 		var options = {babelrc: false};
 
-		if (babelConfig === 'default') {
+		if (!babelConfig || babelConfig === 'default') {
 			objectAssign(options, {presets: [presetStage2, presetES2015]});
 		} else if (babelConfig === 'inherit') {
 			objectAssign(options, {babelrc: true});

--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -35,12 +35,12 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 			filename: filename,
 			sourceMaps: true,
 			ast: false,
-			inputSourceMap: sourceMap && sourceMap.toObject()
+			inputSourceMap: sourceMap && sourceMap.toObject(),
+			babelrc: false
 		};
 
 		if (!babelConfig || babelConfig === 'default') {
 			return objectAssign({}, baseOptions, {
-				babelrc: false,
 				presets: [presetStage2, presetES2015],
 				plugins: [powerAssert, transformRuntime]
 			});

--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -81,7 +81,8 @@ CachingPrecompiler.prototype._createTransform = function (babelConfig) {
 		salt: new Buffer(JSON.stringify({
 			'babel-plugin-espower': require('babel-plugin-espower/package.json').version,
 			'ava': require('../package.json').version,
-			'babel-core': require('babel-core/package.json').version
+			'babel-core': require('babel-core/package.json').version,
+			'babelConfig': babelConfig
 		})),
 		ext: '.js',
 		hash: this._hash.bind(this)

--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -3,20 +3,21 @@ var path = require('path');
 var cachingTransform = require('caching-transform');
 var md5Hex = require('md5-hex');
 var stripBom = require('strip-bom');
+var objectAssign = require('object-assign');
 
 module.exports = CachingPrecompiler;
 
-function CachingPrecompiler(cacheDir) {
+function CachingPrecompiler(cacheDir, babelConfig) {
 	if (!(this instanceof CachingPrecompiler)) {
 		throw new TypeError('Class constructor CachingPrecompiler cannot be invoked without \'new\'');
 	}
 
 	this.cacheDir = cacheDir;
 	this.filenameToHash = {};
-	this.transform = this._createTransform();
+	this.transform = this._createTransform(babelConfig);
 }
 
-CachingPrecompiler.prototype._factory = function (cacheDir) {
+CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 	// This factory method is only called once per process, and only as needed, to defer loading expensive dependencies.
 	var babel = require('babel-core');
 	var convertSourceMap = require('convert-source-map');
@@ -30,15 +31,26 @@ CachingPrecompiler.prototype._factory = function (cacheDir) {
 		// Extract existing source maps from the code.
 		var sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename));
 
-		return {
-			presets: [presetStage2, presetES2015],
-			plugins: [powerAssert, transformRuntime],
+		var baseOptions = {
 			filename: filename,
 			sourceMaps: true,
 			ast: false,
-			babelrc: false,
 			inputSourceMap: sourceMap && sourceMap.toObject()
 		};
+
+		if (!babelConfig || babelConfig === 'default') {
+			return objectAssign({}, baseOptions, {
+				babelrc: false,
+				presets: [presetStage2, presetES2015],
+				plugins: [powerAssert, transformRuntime]
+			});
+		}
+
+		if (babelConfig === 'inherit') {
+			return objectAssign({}, baseOptions, {babelrc: true});
+		}
+
+		return objectAssign({}, baseOptions, babelConfig);
 	}
 
 	return function (code, filename, hash) {
@@ -61,9 +73,9 @@ CachingPrecompiler.prototype._createEspowerPlugin = function (babel) {
 	});
 };
 
-CachingPrecompiler.prototype._createTransform = function () {
+CachingPrecompiler.prototype._createTransform = function (babelConfig) {
 	return cachingTransform({
-		factory: this._factory.bind(this),
+		factory: this._factory.bind(this, babelConfig),
 		cacheDir: this.cacheDir,
 		salt: new Buffer(JSON.stringify({
 			'babel-plugin-espower': require('babel-plugin-espower/package.json').version,

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "update-notifier": "^0.6.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.6.4",
     "cli-table2": "^0.1.9",
     "coveralls": "^2.11.4",
     "delay": "^1.3.0",

--- a/profile.js
+++ b/profile.js
@@ -20,7 +20,11 @@ globals.setTimeout = setTimeout.bind(null);
 globals.clearTimeout = clearTimeout.bind(null);
 
 Promise.longStackTraces();
-var conf = pkgConf.sync('ava');
+var conf = pkgConf.sync('ava', {
+	defaults: {
+		babel: 'default'
+	}
+});
 
 // Define a minimal set of options from the main CLI.
 var cli = meow([

--- a/profile.js
+++ b/profile.js
@@ -63,7 +63,7 @@ var opts = {
 	require: arrify(cli.flags.require),
 	tty: false,
 	cacheDir: cacheDir,
-	precompiled: new CachingPrecompiler(cacheDir).generateHashForFile(file)
+	precompiled: new CachingPrecompiler(cacheDir, conf.babel).generateHashForFile(file)
 };
 
 var events = new EventEmitter();

--- a/readme.md
+++ b/readme.md
@@ -154,7 +154,8 @@ All of the CLI options can be configured in the `ava` section of your `package.j
     "tap": true,
     "require": [
       "babel-register"
-    ]
+    ],
+    "babel": "inherit"
   }
 }
 ```
@@ -422,6 +423,41 @@ AVA comes with builtin support for ES2015 through [Babel 6](https://babeljs.io).
 ### TypeScript support
 
 AVA includes typings for TypeScript. You have to setup transpilation yourself. When you set `module` to `commonjs` in your `tsconfig.json` file, TypeScript will automatically find the type definitions for AVA. You should set `target` to `es2015` to use Promises and async functions.
+
+If you want to customize the babel transpiler for test files, you can do so by adding a `"babel"` key to the `"ava"` section in your package.json file.
+
+```json
+{
+	"ava": {
+		 "babel": {
+			 "presets": [
+					"es2015",
+					"stage-0",
+					"react"
+			 ]
+		 }
+	},
+}
+```
+
+In addition to specifying a custom babel config, you can also use the special `inherit` keyword. When you do this, AVA will allow tests to be transpiled using the configuration defined in your .babelrc file or in package.json/babel. This way, your test files will be transpiled using the same options as your source files, but you won't have to define the options twice.
+
+```json
+{
+	"babel": {
+		"presets": [
+			"es2015",
+			"stage-0",
+			"react"
+		]
+	},
+	"ava": {
+		"babel": "inherit",
+	},
+}
+```
+
+If you do not specify a "babel" key in your ava configuration, or if you set it to `"default"`, AVA will transpile the test files with AVA's default babel configuration.
 
 #### Transpiling Imported Modules
 

--- a/readme.md
+++ b/readme.md
@@ -424,7 +424,9 @@ AVA comes with builtin support for ES2015 through [Babel 6](https://babeljs.io).
 
 AVA includes typings for TypeScript. You have to setup transpilation yourself. When you set `module` to `commonjs` in your `tsconfig.json` file, TypeScript will automatically find the type definitions for AVA. You should set `target` to `es2015` to use Promises and async functions.
 
-If you want to customize the babel transpiler for test files, you can do so by adding a `"babel"` key to the `"ava"` section in your package.json file.
+### Babel Configuration for Test Scripts
+
+If you want to customize the babel transpiler for test files, you can do so by adding a `"babel"` key to the `ava` section in your `package.json` file.
 
 ```json
 {
@@ -440,7 +442,7 @@ If you want to customize the babel transpiler for test files, you can do so by a
 }
 ```
 
-In addition to specifying a custom babel config, you can also use the special `inherit` keyword. When you do this, AVA will allow tests to be transpiled using the configuration defined in your .babelrc file or in package.json/babel. This way, your test files will be transpiled using the same options as your source files, but you won't have to define the options twice.
+In addition to specifying a custom Babel config, you can also use the special `"inherit"` keyword. When you do this, AVA will allow tests to be transpiled using the configuration defined in your `.babelrc` file or in package.json/babel. This way, your test files will be transpiled using the same options as your source files, but you won't have to define the options twice.
 
 ```json
 {
@@ -457,7 +459,25 @@ In addition to specifying a custom babel config, you can also use the special `i
 }
 ```
 
-If you do not specify a "babel" key in your ava configuration, or if you set it to `"default"`, AVA will transpile the test files with AVA's default babel configuration.
+Note: When configuring Babel for tests manually, the espower and transform-runtime plugins will be
+added for you.
+
+## Default Babel Configuration for Test Scripts
+
+If you don't explicitly configure Babel for your tests using the `"babel"` key in package.json, your tests will be transpiled using AVA's default Babel configuration, which is as follows:
+
+```json
+{
+  "presets": [
+    "es2015",
+    "stage-0",
+  ],
+  "plugins": [
+    "espower",
+    "transform-runtime"
+  ]
+}
+```
 
 #### Transpiling Imported Modules
 

--- a/test/api.js
+++ b/test/api.js
@@ -710,11 +710,8 @@ test('Default babel config doesn\'t use .babelrc', function (t) {
 
 	var api = new Api();
 
-	api.run([path.join(__dirname, 'fixture/babelrc/test.js')])
-		.then(
-			function () {
-				t.is(api.passCount, 1);
-			},
-			t.threw
-		);
+	return api.run([path.join(__dirname, 'fixture/babelrc/test.js')])
+		.then(function () {
+			t.is(api.passCount, 1);
+		});
 });

--- a/test/api.js
+++ b/test/api.js
@@ -690,7 +690,6 @@ test('Custom Babel Plugin Support', function (t) {
 	t.plan(1);
 
 	var api = new Api({
-		cacheEnabled: false,
 		babelConfig: {
 			presets: ['es2015', 'stage-2'],
 			plugins: [testDoublerPlugin]
@@ -709,9 +708,7 @@ test('Custom Babel Plugin Support', function (t) {
 test('Default babel config doesn\'t use .babelrc', function (t) {
 	t.plan(1);
 
-	var api = new Api({
-		cacheEnabled: false
-	});
+	var api = new Api();
 
 	api.run([path.join(__dirname, 'fixture/babelrc/test.js')])
 		.then(

--- a/test/api.js
+++ b/test/api.js
@@ -5,6 +5,7 @@ var rimraf = require('rimraf');
 var fs = require('fs');
 var test = require('tap').test;
 var Api = require('../api');
+var testDoublerPlugin = require('./fixture/babel-plugin-test-doubler');
 
 test('must be called with new', function (t) {
 	t.throws(function () {
@@ -683,4 +684,40 @@ test('verify test count', function (t) {
 		t.is(api.skipCount, 1);
 		t.is(api.todoCount, 1);
 	});
+});
+
+test('Custom Babel Plugin Support', function (t) {
+	t.plan(1);
+
+	var api = new Api({
+		cacheEnabled: false,
+		babelConfig: {
+			presets: ['es2015', 'stage-2'],
+			plugins: [testDoublerPlugin]
+		}
+	});
+
+	api.run([path.join(__dirname, 'fixture/es2015.js')])
+		.then(
+			function () {
+				t.is(api.passCount, 2);
+			},
+			t.threw
+		);
+});
+
+test('Default babel config doesn\'t use .babelrc', function (t) {
+	t.plan(1);
+
+	var api = new Api({
+		cacheEnabled: false
+	});
+
+	api.run([path.join(__dirname, 'fixture/babelrc/test.js')])
+		.then(
+			function () {
+				t.is(api.passCount, 1);
+			},
+			t.threw
+		);
 });

--- a/test/caching-precompiler.js
+++ b/test/caching-precompiler.js
@@ -3,6 +3,8 @@ var fs = require('fs');
 var path = require('path');
 var test = require('tap').test;
 var uniqueTempDir = require('unique-temp-dir');
+var sinon = require('sinon');
+var babel = require('babel-core');
 
 var CachingPrecompiler = require('../lib/caching-precompiler');
 
@@ -18,9 +20,14 @@ function endsWithMap(filename) {
 	return /\.js$/.test(filename);
 }
 
+test('before', t => {
+	sinon.spy(babel, 'transform');
+	t.end();
+});
+
 test('creation with new', function (t) {
 	var tempDir = uniqueTempDir();
-	var precompiler = new CachingPrecompiler(tempDir);
+	var precompiler = new CachingPrecompiler(tempDir, null);
 	t.is(precompiler.cacheDir, tempDir);
 	t.end();
 });
@@ -28,14 +35,14 @@ test('creation with new', function (t) {
 test('must be called with new', function (t) {
 	t.throws(function () {
 		var cachingPrecompiler = CachingPrecompiler;
-		cachingPrecompiler(uniqueTempDir());
+		cachingPrecompiler(uniqueTempDir(), null);
 	}, {message: 'Class constructor CachingPrecompiler cannot be invoked without \'new\''});
 	t.end();
 });
 
 test('adds files and source maps to the cache directory as needed', function (t) {
 	var tempDir = uniqueTempDir();
-	var precompiler = new CachingPrecompiler(tempDir);
+	var precompiler = new CachingPrecompiler(tempDir, null);
 
 	t.false(fs.existsSync(tempDir), 'cache directory is not created before it is needed');
 
@@ -46,5 +53,91 @@ test('adds files and source maps to the cache directory as needed', function (t)
 	t.is(files.length, 2);
 	t.is(files.filter(endsWithJs).length, 1, 'one .js file is saved to the cache');
 	t.is(files.filter(endsWithMap).length, 1, 'one .map file is saved to the cache');
+	t.end();
+});
+
+test('uses default babel options when !babelConfig', function (t) {
+	var tempDir = uniqueTempDir();
+	var precompiler = new CachingPrecompiler(tempDir, null);
+	babel.transform.reset();
+
+	precompiler.precompileFile(fixture('es2015.js'));
+
+	t.true(babel.transform.calledOnce);
+	var options = babel.transform.firstCall.args[1];
+
+	t.true('filename' in options);
+	t.true(options.sourceMaps);
+	t.false(options.ast);
+	t.true('inputSourceMap' in options);
+	t.false(options.babelrc);
+	t.true(Array.isArray(options.presets));
+	t.true(Array.isArray(options.plugins));
+	t.end();
+});
+
+test('uses default babel options when babelConfig === "default"', function (t) {
+	var tempDir = uniqueTempDir();
+	var precompiler = new CachingPrecompiler(tempDir, 'default');
+	babel.transform.reset();
+
+	precompiler.precompileFile(fixture('es2015.js'));
+
+	t.true(babel.transform.calledOnce);
+	var options = babel.transform.firstCall.args[1];
+
+	t.true('filename' in options);
+	t.true(options.sourceMaps);
+	t.false(options.ast);
+	t.true('inputSourceMap' in options);
+	t.false(options.babelrc);
+	t.true(Array.isArray(options.presets));
+	t.true(Array.isArray(options.plugins));
+	t.end();
+});
+
+test('allows babel config from package.json/babel when babelConfig === "inherit"', function (t) {
+	var tempDir = uniqueTempDir();
+	var precompiler = new CachingPrecompiler(tempDir, 'inherit');
+	babel.transform.reset();
+
+	precompiler.precompileFile(fixture('es2015.js'));
+
+	t.true(babel.transform.calledOnce);
+	var options = babel.transform.firstCall.args[1];
+
+	t.true('filename' in options);
+	t.true(options.sourceMaps);
+	t.false(options.ast);
+	t.true('inputSourceMap' in options);
+	t.true(options.babelrc);
+	t.end();
+});
+
+test('uses babelConfig for babel options when babelConfig is an object', function (t) {
+	var tempDir = uniqueTempDir();
+	var precompiler = new CachingPrecompiler(tempDir, {
+		presets: ['stage-2', 'es2015'],
+		plugins: []
+	});
+	babel.transform.reset();
+
+	precompiler.precompileFile(fixture('es2015.js'));
+
+	t.true(babel.transform.calledOnce);
+	var options = babel.transform.firstCall.args[1];
+
+	t.true('filename' in options);
+	t.true(options.sourceMaps);
+	t.false(options.ast);
+	t.true('inputSourceMap' in options);
+	t.false(options.babelrc);
+	t.deepEqual(options.presets, ['stage-2', 'es2015']);
+	t.deepEqual(options.plugins, []);
+	t.end();
+});
+
+test('after', t => {
+	babel.transform.restore();
 	t.end();
 });

--- a/test/caching-precompiler.js
+++ b/test/caching-precompiler.js
@@ -20,7 +20,7 @@ function endsWithMap(filename) {
 	return /\.js$/.test(filename);
 }
 
-test('before', t => {
+test('before', function (t) {
 	sinon.spy(babel, 'transform');
 	t.end();
 });
@@ -137,7 +137,7 @@ test('uses babelConfig for babel options when babelConfig is an object', functio
 	t.end();
 });
 
-test('after', t => {
+test('after', function (t) {
 	babel.transform.restore();
 	t.end();
 });

--- a/test/caching-precompiler.js
+++ b/test/caching-precompiler.js
@@ -20,10 +20,7 @@ function endsWithMap(filename) {
 	return /\.js$/.test(filename);
 }
 
-test('before', function (t) {
-	sinon.spy(babel, 'transform');
-	t.end();
-});
+sinon.spy(babel, 'transform');
 
 test('creation with new', function (t) {
 	var tempDir = uniqueTempDir();
@@ -53,26 +50,6 @@ test('adds files and source maps to the cache directory as needed', function (t)
 	t.is(files.length, 2);
 	t.is(files.filter(endsWithJs).length, 1, 'one .js file is saved to the cache');
 	t.is(files.filter(endsWithMap).length, 1, 'one .map file is saved to the cache');
-	t.end();
-});
-
-test('uses default babel options when !babelConfig', function (t) {
-	var tempDir = uniqueTempDir();
-	var precompiler = new CachingPrecompiler(tempDir, null);
-	babel.transform.reset();
-
-	precompiler.precompileFile(fixture('es2015.js'));
-
-	t.true(babel.transform.calledOnce);
-	var options = babel.transform.firstCall.args[1];
-
-	t.true('filename' in options);
-	t.true(options.sourceMaps);
-	t.false(options.ast);
-	t.true('inputSourceMap' in options);
-	t.false(options.babelrc);
-	t.true(Array.isArray(options.presets));
-	t.true(Array.isArray(options.plugins));
 	t.end();
 });
 
@@ -133,11 +110,6 @@ test('uses babelConfig for babel options when babelConfig is an object', functio
 	t.true('inputSourceMap' in options);
 	t.false(options.babelrc);
 	t.deepEqual(options.presets, ['stage-2', 'es2015']);
-	t.deepEqual(options.plugins, []);
-	t.end();
-});
-
-test('after', function (t) {
-	babel.transform.restore();
+	t.equal(options.plugins.length, 2);
 	t.end();
 });

--- a/test/fixture/babel-plugin-test-doubler.js
+++ b/test/fixture/babel-plugin-test-doubler.js
@@ -1,0 +1,46 @@
+/*
+ A Babel plugin that causes each AVA test to be duplicated with a new title.
+
+     test('foo', t => {});
+
+ becomes
+
+     test('foo', t => {});
+     test('repeated test: foo', t => {});
+
+  This is used by some integration tests to validate correct handling of Babel config options.
+*/
+
+function plugin(babel) {
+	var t = babel.types;
+	var anonCount = 1;
+
+	return {
+		visitor: {
+			CallExpression: function (path) {
+				var node = path.node;
+				var callee = node.callee;
+				var args = node.arguments;
+				if (!path.generated && callee.type === 'Identifier' && callee.name === 'test') {
+					if (args.length === 1) {
+						args = [t.StringLiteral('repeated test: anonymous' + anonCount++), args[0]];
+					} else if (args.length === 2 && args[0].type === 'StringLiteral') {
+						if (/^repeated test/.test(args[0].value)) {
+							return;
+						}
+						args = args.slice();
+						args[0] = t.StringLiteral('repeated test: ' + args[0].value);
+					} else {
+						throw new Error('the plugin does not know how to handle this call to test');
+					}
+					path.insertAfter(t.CallExpression(
+						t.Identifier('test'),
+						args
+					));
+				}
+			}
+		}
+	};
+}
+
+module.exports = plugin;

--- a/test/fixture/babel-plugin-test-doubler.js
+++ b/test/fixture/babel-plugin-test-doubler.js
@@ -21,7 +21,7 @@ function plugin(babel) {
 				var node = path.node;
 				var callee = node.callee;
 				var args = node.arguments;
-				if (!path.generated && callee.type === 'Identifier' && callee.name === 'test') {
+				if (callee.type === 'Identifier' && callee.name === 'test') {
 					if (args.length === 1) {
 						args = [t.StringLiteral('repeated test: anonymous' + anonCount++), args[0]];
 					} else if (args.length === 2 && args[0].type === 'StringLiteral') {


### PR DESCRIPTION
Here's an initial commit that allows package owners to specify a babel config for tests under the package.json/ava key.

This conforms to the proposal in the following comment: https://github.com/sindresorhus/ava/issues/448#issuecomment-187694472

I chose not to implement an extends key discussed in the thread because 1) it adds to the complexity, 2) I personally don't need it, and 3) how to solve that request is still somewhat unresolved. If needed, someone can add that later in another pull request.

Let me know what you think. I'm a little unsure about whether my method for obtaining babelConfig is the best one.