### PR TITLE
Return thrown error/rejected promise from t.throws

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -78,7 +78,7 @@ x.throws = function (fn, err, msg) {
 			.then(function () {
 				x.throws(noop, err, msg);
 			}, function (fnErr) {
-				x.throws(function () {
+				return x.throws(function () {
 					throw fnErr;
 				}, err, msg);
 			});
@@ -92,7 +92,18 @@ x.throws = function (fn, err, msg) {
 			};
 		}
 
-		assert.throws(fn, err, msg);
+		var result;
+
+		assert.throws(function () {
+			try {
+				fn();
+			} catch (error) {
+				result = error;
+				throw error;
+			}
+		}, err, msg);
+
+		return result;
 	} catch (err) {
 		test(false, create(err.actual, err.expected, err.operator, err.message, x.throws));
 	}

--- a/readme.md
+++ b/readme.md
@@ -566,6 +566,8 @@ Assert that `function` throws an error, or `promise` rejects with an error.
 
 `error` can be a constructor, regex, error message or validation function.
 
+Returns the error thrown by `function` or the rejection reason of `promise`.
+
 ### .notThrows(function|promise, [message])
 
 Assert that `function` doesn't throw an `error` or `promise` resolves.

--- a/test/assert.js
+++ b/test/assert.js
@@ -1,5 +1,6 @@
 'use strict';
 var test = require('tap').test;
+var Promise = require('bluebird');
 var assert = require('../lib/assert');
 
 test('.pass()', function (t) {
@@ -180,6 +181,26 @@ test('.throws()', function (t) {
 	});
 
 	t.end();
+});
+
+test('.throws() returns the thrown error', function (t) {
+	var expected = new Error();
+	var actual = assert.throws(function () {
+		throw expected;
+	});
+
+	t.is(actual, expected);
+
+	t.end();
+});
+
+test('.throws() returns the rejection reason of promise', function (t) {
+	var expected = new Error();
+
+	assert.throws(Promise.reject(expected)).then(function (actual) {
+		t.is(actual, expected);
+		t.end();
+	});
 });
 
 test('.notThrows()', function (t) {


### PR DESCRIPTION
If a `throws` assertion passes, we should return the reason for said pass. That entails; 

* A thrown Error.
* A Promise rejection.
* An Observable error. 

Loosely based on the description of #493. I consider it to be loosely based on it, because of the following differences (in the Promised-land): 

```js
// Desired
test(t => {
  const expected = new Error('foo');
  const actual = t.throws(() => Promise.reject(expected));
  t.is(expected, actual); // true
})

// Implemented
test(t => {
  const expected = new Error('foo');
  const actual = t.throws(() => Promise.reject(expected));
  t.is(expected, actual.reason); //true 
})
```

--- 

I hijacked the `result.reason` property because I wasn't fully comfortable in excluding the base `result` properties out of a successful `throws` assertion, which was heavily used in `test/promise` and `test/observable`. However this can be changed quite easily, to more closely reflect the initial desires of #493. 

--- 

Haven't taken a stab at docs for the changes made yet, I'll get on top of that on my way home from work.