### PR TITLE
[breaking] Don't convert non-Error promise rejection reason

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -79,11 +79,7 @@ x.throws = function (fn, err, msg) {
 				x.throws(noop, err, msg);
 			}, function (fnErr) {
 				x.throws(function () {
-					if (fnErr instanceof Error) {
-						throw fnErr;
-					} else {
-						throw new Error(fnErr);
-					}
+					throw fnErr;
 				}, err, msg);
 			});
 	}

--- a/readme.md
+++ b/readme.md
@@ -560,7 +560,7 @@ Assert that `value` is not deep equal to `expected`.
 
 ### .throws(function|promise, [error, [message]])
 
-Assert that `function` throws an error or `promise` rejects.
+Assert that `function` throws an error, or `promise` rejects with an error.
 
 `error` can be a constructor, regex, error message or validation function.
 

--- a/test/promise.js
+++ b/test/promise.js
@@ -210,28 +210,15 @@ test('throws with string argument will reject if message does not match', functi
 	});
 });
 
-test('handle throws with regex with string reject', function (t) {
-	ava(function (a) {
-		a.plan(1);
-
-		var promise = Promise.reject('abc');
-		return a.throws(promise, /abc/);
-	}).run().then(function (result) {
-		t.is(result.passed, true);
-		t.is(result.result.assertCount, 1);
-		t.end();
-	});
-});
-
-test('handle throws with string with string reject', function (t) {
+test('does not handle throws with string reject', function (t) {
 	ava(function (a) {
 		a.plan(1);
 
 		var promise = Promise.reject('abc');
 		return a.throws(promise, 'abc');
 	}).run().then(function (result) {
-		t.is(result.passed, true);
-		t.is(result.result.assertCount, 1);
+		t.is(result.passed, false);
+		t.is(result.reason.name, 'AssertionError');
 		t.end();
 	});
 });


### PR DESCRIPTION
Promises that are rejected with a non-Error are currently passing expectations as [we're converting to an Error](https://github.com/sindresorhus/ava/blob/f77ded959a0e7de6e9bf65d8c2fd6625bc59ba47/lib/assert.js#L85) in `lib/assert`. 


This PR changes the behaviour of `t.throws` so that it no longer considers the following example a pass: 
```js
test(async t => {
 await t.throws(Promise.reject('foo'), 'foo');
});
```
If the rejection reason is a non-Error, `core-assert` catches this which results in an AssertionError.

Whereas the following would pass with flying colors:
```js
test(async t => {
  await t.throws(Promise.reject(new Error('foo'), 'foo');
});
```

---

Docs for `t.throws` saw a minor addition; 
> Assert that function throws an error**,** or promise rejects **with an error.**

Fixes #468 