### PR TITLE
Add t.context to TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,8 @@ export interface TestContext extends AssertContext {
 	plan(count: number): void;
 
 	skip: AssertContext;
+
+	context: any;
 }
 export interface CallbackTestContext extends TestContext {
 	/**


### PR DESCRIPTION
As noted by @SamVerschueren, #571 missed the definition for `t.context`. This PR adds that property to the TypeScript definitions.