### PR TITLE
Remove unnecessary `counted` variable in api.js

### DIFF
--- a/api.js
+++ b/api.js
@@ -181,13 +181,7 @@ Api.prototype.run = function (files) {
 
 			return new Promise(function (resolve) {
 				tests.forEach(function (test) {
-					var counted = false;
-
 					function tryRun() {
-						if (counted) {
-							return;
-						}
-
 						if (++statsCount === self.fileCount) {
 							self.emit('ready');
 


### PR DESCRIPTION
Remove declaration and usage for unnecessary `counted` variable in ava/api.js.
This should resolve issue #584 