### PR TITLE
Add `match` CLI option to run only matching tests

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -49,6 +49,7 @@ var cli = meow([
 	'  --tap, -t        Generate TAP output',
 	'  --verbose, -v    Enable verbose output',
 	'  --no-cache       Disable the transpiler cache',
+	'  --match, -m      Only run tests with matching title (Can be repeated)',
 	// Leave --watch and --sources undocumented until they're stable enough
 	// '  --watch, -w      Re-run tests when tests and source files change',
 	// '  --source         Pattern to match source files so tests can be re-run (Can be repeated)',
@@ -67,7 +68,8 @@ var cli = meow([
 	string: [
 		'_',
 		'require',
-		'source'
+		'source',
+		'match'
 	],
 	boolean: [
 		'fail-fast',
@@ -82,7 +84,8 @@ var cli = meow([
 		v: 'verbose',
 		r: 'require',
 		s: 'serial',
-		w: 'watch'
+		w: 'watch',
+		m: 'match'
 	}
 });
 
@@ -98,7 +101,8 @@ var api = new Api({
 	serial: cli.flags.serial,
 	require: arrify(cli.flags.require),
 	cacheEnabled: cli.flags.cache !== false,
-	explicitTitles: cli.flags.watch
+	explicitTitles: cli.flags.watch,
+	match: arrify(cli.flags.match)
 });
 
 var reporter;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ require('./lib/test-worker').avaRequired = true;
 var opts = globals.options;
 var runner = new Runner({
 	serial: opts.serial,
-	bail: opts.failFast
+	bail: opts.failFast,
+	match: opts.match
 });
 
 // check if the test is being run without AVA cli

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,6 +3,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var Promise = require('bluebird');
 var optionChain = require('option-chain');
+var matcher = require('matcher');
 var TestCollection = require('./test-collection');
 
 function noop() {}
@@ -42,6 +43,7 @@ function Runner(options) {
 	this.tests = new TestCollection();
 	this._bail = options.bail;
 	this._serial = options.serial;
+	this._match = options.match;
 
 	this._addTestResult = this._addTestResult.bind(this);
 }
@@ -67,6 +69,10 @@ optionChain(chainableMethods, function (opts, title, fn) {
 
 	if (this._serial) {
 		opts.serial = true;
+	}
+
+	if (opts.type === 'test' && (this._match && this._match.length > 0) && title !== null) {
+		opts.skipped = matcher([title], this._match).length === 0;
 	}
 
 	this.tests.add({

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -71,8 +71,8 @@ optionChain(chainableMethods, function (opts, title, fn) {
 		opts.serial = true;
 	}
 
-	if (opts.type === 'test' && (this._match && this._match.length > 0) && title !== null) {
-		opts.skipped = matcher([title], this._match).length === 0;
+	if (opts.type === 'test' && title !== null && this._match && this._match.length > 0) {
+		opts.exclusive = matcher([title], this._match).length > 0;
 	}
 
 	this.tests.add({

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "is-promise": "^2.1.0",
     "last-line-stream": "^1.0.0",
     "loud-rejection": "^1.2.0",
+    "matcher": "^0.1.1",
     "max-timeout": "^1.0.0",
     "md5-hex": "^1.2.0",
     "meow": "^3.7.0",

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,7 @@ $ ava --help
     --tap, -t        Generate TAP output
     --verbose, -v    Enable verbose output
     --no-cache       Disable the transpiler cache
+    --match, -m      Only run tests with matching title (Can be repeated)',
 
   Examples
     ava
@@ -134,6 +135,32 @@ Directories are recursive by default. Directories named `fixtures` and `helpers`
 
 When using `npm test`, you can pass positional arguments directly `npm test test2.js`, but flags needs to be passed like `npm test -- --verbose`.
 
+### The `--match` flag
+
+The `--match` flag allows you to run a subset of the tests in your suite that have a matching title. This is achieved with simple wildcard patterns. For more information, check out [sindresorhus/matcher](https://github.com/sindresorhus/matcher).
+
+```
+# match titles ending with 'foo'
+$ ava --match='*foo'
+
+# match titles starting with 'foo'
+$ ava --match='foo*'
+
+# match titles containing 'foo'
+$ ava --match='*foo*'
+
+# match titles not containing 'foo'
+$ ava --match='!*foo*'
+
+# match titles starting with 'foo' and ending with 'bar'
+$ ava --match='foo*bar'
+
+# match titles starting with 'foo' or ending with 'bar'
+$ ava --match='foo*' --match='*bar'
+```
+
+*Tests without a title will not run if* **any** *match pattern is supplied.*
+
 ## Configuration
 
 All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt.
@@ -144,6 +171,10 @@ All of the CLI options can be configured in the `ava` section of your `package.j
     "files": [
       "my-test-folder/*.js",
       "!**/not-this-file.js"
+    ],
+    "match": [
+      "*oo",
+      "!foo"
     ],
     "failFast": true,
     "tap": true,

--- a/readme.md
+++ b/readme.md
@@ -135,32 +135,6 @@ Directories are recursive by default. Directories named `fixtures` and `helpers`
 
 When using `npm test`, you can pass positional arguments directly `npm test test2.js`, but flags needs to be passed like `npm test -- --verbose`.
 
-### The `--match` flag
-
-The `--match` flag allows you to run a subset of the tests in your suite that have a matching title. This is achieved with simple wildcard patterns. For more information, check out [sindresorhus/matcher](https://github.com/sindresorhus/matcher).
-
-```
-# match titles ending with 'foo'
-$ ava --match='*foo'
-
-# match titles starting with 'foo'
-$ ava --match='foo*'
-
-# match titles containing 'foo'
-$ ava --match='*foo*'
-
-# match titles not containing 'foo'
-$ ava --match='!*foo*'
-
-# match titles starting with 'foo' and ending with 'bar'
-$ ava --match='foo*bar'
-
-# match titles starting with 'foo' or ending with 'bar'
-$ ava --match='foo*' --match='*bar'
-```
-
-*Tests without a title will not run if* **any** *match pattern is supplied.*
-
 ## Configuration
 
 All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt.
@@ -276,6 +250,49 @@ test.only('will be run', t => {
 	t.pass();
 });
 ```
+
+### Matched-tests
+
+The `--match` flag allows you to run a subset of the tests in your suite that have a matching title. This is achieved with simple wildcard patterns. For more information, check out [matcher](https://github.com/sindresorhus/matcher).
+
+```
+# match titles ending with 'foo'
+$ ava --match='*foo'
+
+# match titles starting with 'foo'
+$ ava --match='foo*'
+
+# match titles containing 'foo'
+$ ava --match='*foo*'
+
+# match titles not containing 'foo'
+$ ava --match='!*foo*'
+
+# match titles starting with 'foo' and ending with 'bar'
+$ ava --match='foo*bar'
+
+# match titles starting with 'foo' or ending with 'bar'
+$ ava --match='foo*' --match='*bar'
+```
+
+```js
+// $ ava --match='*oo'
+
+test('foo will run', t => {
+	t.pass();
+});
+
+test.only('moo will also run', t => {
+	t.pass();
+});
+
+// won't run!
+test(function () {
+	t.fail();
+});
+```
+
+Note that a match pattern takes precedence over `.only`, and *any tests without an explicit title will* **not run** *if a match pattern is supplied.*
 
 ### Skip-tests
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -112,7 +112,7 @@ test('pkg-conf: pkg-overrides', function (t) {
 });
 
 test('pkg-conf: cli takes precedence', function (t) {
-	execCli(['--no-serial', '--cache', '--no-fail-fast', '--require=./required.js', 'c.js'], {dirname: 'fixture/pkg-conf/precedence'}, function (err) {
+	execCli(['--match=foo*', '--no-serial', '--cache', '--no-fail-fast', '--require=./required.js', 'c.js'], {dirname: 'fixture/pkg-conf/precedence'}, function (err) {
 		t.ifError(err);
 		t.end();
 	});
@@ -153,6 +153,13 @@ test('watcher works', function (t) {
 				killed = true;
 			}
 		}
+	});
+});
+
+test('--match works', function (t) {
+	execCli(['-m=foo', '-m=bar', '-m=!baz', '-m=t* a* f*', '-m=!t* a* n* f*', 'fixture/matcher-skip.js'], function (err) {
+		t.ifError(err);
+		t.end();
 	});
 });
 

--- a/test/fixture/matcher-skip.js
+++ b/test/fixture/matcher-skip.js
@@ -1,0 +1,21 @@
+import test from '../../';
+
+test('foo', t => {
+	t.pass();
+});
+
+test('bar', t => {
+	t.pass();
+});
+
+test('baz', t => {
+	t.fail();
+});
+
+test('tests are fun', t => {
+	t.pass();
+});
+
+test('tests are not fun', t => {
+	t.fail();
+});

--- a/test/fixture/pkg-conf/precedence/c.js
+++ b/test/fixture/pkg-conf/precedence/c.js
@@ -7,6 +7,7 @@ test(t => {
 	t.is(opts.failFast, false);
 	t.is(opts.serial, false);
 	t.is(opts.cacheEnabled, true);
+	t.same(opts.match, ['foo*']);
 	t.same(opts.require, [
 		path.join(__dirname, "required.js")
 	]);

--- a/test/fixture/pkg-conf/precedence/package.json
+++ b/test/fixture/pkg-conf/precedence/package.json
@@ -6,6 +6,7 @@
     "serial": true,
     "failFast": true,
     "cache": false,
+    "match": ["*"],
     "require": "./default-required.js"
   }
 }

--- a/test/runner.js
+++ b/test/runner.js
@@ -379,8 +379,8 @@ test('options.bail + serial - tests will never happen (async)', function (t) {
 	});
 });
 
-test('options.match will skip tests with non-matching titles', function (t) {
-	t.plan(6);
+test('options.match will not run tests with non-matching titles', function (t) {
+	t.plan(5);
 
 	var runner = new Runner({
 		match: ['*oo', '!foo']
@@ -399,13 +399,13 @@ test('options.match will skip tests with non-matching titles', function (t) {
 	});
 
 	runner.test(function () {
-		t.pass();
+		t.fail();
 	});
 
 	runner.run({}).then(function () {
-		t.is(runner.stats.skipCount, 1);
-		t.is(runner.stats.passCount, 3);
-		t.is(runner.stats.testCount, 4);
+		t.is(runner.stats.skipCount, 0);
+		t.is(runner.stats.passCount, 2);
+		t.is(runner.stats.testCount, 2);
 		t.end();
 	});
 });
@@ -431,6 +431,29 @@ test('options.match hold no effect on hooks with titles', function (t) {
 		t.is(runner.stats.skipCount, 0);
 		t.is(runner.stats.passCount, 1);
 		t.is(runner.stats.testCount, 1);
+		t.end();
+	});
+});
+
+test('options.match overrides .only', function (t) {
+	t.plan(5);
+
+	var runner = new Runner({
+		match: ['*oo']
+	});
+
+	runner.test('moo', function () {
+		t.pass();
+	});
+
+	runner.test.only('boo', function () {
+		t.pass();
+	});
+
+	runner.run({}).then(function () {
+		t.is(runner.stats.skipCount, 0);
+		t.is(runner.stats.passCount, 2);
+		t.is(runner.stats.testCount, 2);
 		t.end();
 	});
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -378,3 +378,59 @@ test('options.bail + serial - tests will never happen (async)', function (t) {
 		}, 250);
 	});
 });
+
+test('options.match will skip tests with non-matching titles', function (t) {
+	t.plan(6);
+
+	var runner = new Runner({
+		match: ['*oo', '!foo']
+	});
+
+	runner.test('mhm. grass tasty. moo', function () {
+		t.pass();
+	});
+
+	runner.test('juggaloo', function () {
+		t.pass();
+	});
+
+	runner.test('foo', function () {
+		t.fail();
+	});
+
+	runner.test(function () {
+		t.pass();
+	});
+
+	runner.run({}).then(function () {
+		t.is(runner.stats.skipCount, 1);
+		t.is(runner.stats.passCount, 3);
+		t.is(runner.stats.testCount, 4);
+		t.end();
+	});
+});
+
+test('options.match hold no effect on hooks with titles', function (t) {
+	t.plan(4);
+
+	var runner = new Runner({
+		match: ['!before*']
+	});
+
+	var actual;
+
+	runner.before('before hook with title', function () {
+		actual = 'foo';
+	});
+
+	runner.test('after', function () {
+		t.is(actual, 'foo');
+	});
+
+	runner.run({}).then(function () {
+		t.is(runner.stats.skipCount, 0);
+		t.is(runner.stats.passCount, 1);
+		t.is(runner.stats.testCount, 1);
+		t.end();
+	});
+});


### PR DESCRIPTION
Add a `match` option for running a specific set of tests with titles matching the given pattern. Leverages [matcher](https://github.com/sindresorhus/matcher) internally, so `!` and `*` is supported. 

```
ava --match='foo*' --match='!*bar' /test/*.js

# shorthand
ava -m='foo*' -m='!*bar' /test/*.js
```

This would run all tests inside `/test` with a title starting with `foo` and not ending with `bar`. 

The match option can also be configured in the `ava` section of `package.json`. 

```json
{
  "ava": {
    "match": [
      "foo*"
    ]
  }
}
```

Fixes #476 