### PR TITLE
no longer ignore cli.js when linting

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -125,10 +125,10 @@ api.on('stderr', logger.stderr);
 var files = cli.input.length ? cli.input : arrify(conf.files);
 if (files.length === 0) {
 	files = [
-			'test.js',
-			'test-*.js',
-			'test'
-		];
+		'test.js',
+		'test-*.js',
+		'test'
+	];
 }
 
 if (cli.flags.watch) {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
   },
   "xo": {
     "ignore": [
-      "cli.js",
       "bench/*/*.js"
     ]
   }


### PR DESCRIPTION
New XO seems capable of linting `cli.js`.