### PR TITLE
try to fix flaky api test

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -675,11 +675,12 @@ test('verify test count', function (t) {
 	t.is(api.skipCount, 0);
 	t.is(api.todoCount, 0);
 
-	api.run([path.join(__dirname, 'fixture/test-count.js')])
-		.then(function () {
-			t.is(api.passCount, 1);
-			t.is(api.failCount, 1);
-			t.is(api.skipCount, 1);
-			t.is(api.todoCount, 1);
-		});
+	return api.run([
+		path.join(__dirname, 'fixture/test-count.js')
+	]).then(function () {
+		t.is(api.passCount, 1);
+		t.is(api.failCount, 1);
+		t.is(api.skipCount, 1);
+		t.is(api.todoCount, 1);
+	});
 });


### PR DESCRIPTION
This test has failed twice now, see <https://travis-ci.org/sindresorhus/ava/jobs/113902915>. I can't reproduce the error locally, perhaps there is an error that's being swallowed.

Return the promise so tap can report any errors and isn't somehow tempted to end the test early.