### PR TITLE
Don't run tests if --match has no matches

### DIFF
--- a/api.js
+++ b/api.js
@@ -28,6 +28,7 @@ function Api(options) {
 
 	this.options = options || {};
 	this.options.require = (this.options.require || []).map(resolveCwd);
+	this.options.match = this.options.match || [];
 
 	this.excludePatterns = [
 		'!**/node_modules/**',
@@ -198,6 +199,20 @@ Api.prototype.run = function (files) {
 
 			return new Promise(function (resolve) {
 				function run() {
+					if (self.options.match.length > 0 && !self.hasExclusive) {
+						self._handleExceptions({
+							exception: new AvaError('Couldn\'t find any matching tests'),
+							file: undefined
+						});
+
+						tests.forEach(function (test) {
+							// No tests will be run so tear down the child processes.
+							test.send('teardown');
+						});
+						resolve([]);
+						return;
+					}
+
 					self.emit('ready');
 
 					var method = self.options.serial ? 'mapSeries' : 'map';

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -43,7 +43,7 @@ function Runner(options) {
 	this.tests = new TestCollection();
 	this._bail = options.bail;
 	this._serial = options.serial;
-	this._match = options.match;
+	this._match = options.match || [];
 
 	this._addTestResult = this._addTestResult.bind(this);
 }
@@ -71,8 +71,8 @@ optionChain(chainableMethods, function (opts, title, fn) {
 		opts.serial = true;
 	}
 
-	if (opts.type === 'test' && title !== null && this._match && this._match.length > 0) {
-		opts.exclusive = matcher([title], this._match).length > 0;
+	if (opts.type === 'test' && this._match.length > 0) {
+		opts.exclusive = title !== null && matcher([title], this._match).length === 1;
 	}
 
 	this.tests.add({

--- a/test/api.js
+++ b/test/api.js
@@ -715,3 +715,18 @@ test('Default babel config doesn\'t use .babelrc', function (t) {
 			t.is(api.passCount, 1);
 		});
 });
+
+test('using --match with no matching tests causes an AvaError to be emitted', function (t) {
+	t.plan(2);
+
+	var api = new Api({
+		match: ['can\'t match this']
+	});
+
+	api.on('error', function (err) {
+		t.is(err.name, 'AvaError');
+		t.match(err.message, /Couldn't find any matching tests/);
+	});
+
+	return api.run([path.join(__dirname, 'fixture/match-no-match.js')]);
+});

--- a/test/fixture/match-no-match.js
+++ b/test/fixture/match-no-match.js
@@ -1,0 +1,13 @@
+import test from 'ava';
+
+test('foo', t => {
+	t.pass();
+});
+
+test.only('bar', t => {
+	t.pass();
+});
+
+test.only(t => {
+	t.pass();
+});

--- a/test/fixture/pkg-conf/precedence/c.js
+++ b/test/fixture/pkg-conf/precedence/c.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 const opts = JSON.parse(process.argv[2]);
 
-test(t => {
+test('foo', t => {
 	t.is(opts.failFast, false);
 	t.is(opts.serial, false);
 	t.is(opts.cacheEnabled, true);


### PR DESCRIPTION
First commit does some refactoring and fixes a rare race condition where tests are run prematurely.

Second commit implements my suggestions from #606.