### PR TITLE
remove color from test title in mini reporter

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -70,19 +70,16 @@ MiniReporter.prototype.prefix = function (str) {
 };
 
 MiniReporter.prototype._test = function (test) {
-	var title;
+	var title = test.title;
 
 	if (test.todo) {
-		title = colors.todo('- ' + test.title);
 		this.todoCount++;
 	} else if (test.skip) {
-		title = colors.skip('- ' + test.title);
 		this.skipCount++;
 	} else if (test.error) {
 		title = colors.error(test.title);
 		this.failCount++;
 	} else {
-		title = colors.pass(test.title);
 		this.passCount++;
 	}
 

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -120,7 +120,7 @@ test('skipped test', function (t) {
 
 	var expectedOutput = [
 		' ',
-		' ⠋ ' + chalk.yellow('- skipped'),
+		' ⠋ ' + chalk.yellow('skipped'),
 		'',
 		'   ' + chalk.yellow('1 skipped')
 	].join('\n');
@@ -140,7 +140,7 @@ test('todo test', function (t) {
 
 	var expectedOutput = [
 		' ',
-		' ⠋ ' + chalk.blue('- todo'),
+		' ⠋ ' + chalk.blue('todo'),
 		'',
 		'   ' + chalk.blue('1 todo')
 	].join('\n');


### PR DESCRIPTION
too much green when the result count is also in green

and with `todo` and `skip` tests it doesn't matter as they're shown too fast anyways