### PR TITLE
Don't crash watch mode when tests files fail to transpile

### DIFF
--- a/api.js
+++ b/api.js
@@ -194,9 +194,6 @@ Api.prototype.run = function (files) {
 
 			var tests = files.map(self._runFile);
 
-			// receive test count from all files and then run the tests
-			var unreportedFiles = self.fileCount;
-
 			return new Promise(function (resolve) {
 				function run() {
 					if (self.options.match.length > 0 && !self.hasExclusive) {
@@ -238,6 +235,8 @@ Api.prototype.run = function (files) {
 					}));
 				}
 
+				// receive test count from all files and then run the tests
+				var unreportedFiles = self.fileCount;
 				tests.forEach(function (test) {
 					var tried = false;
 					function tryRun() {

--- a/test/api.js
+++ b/test/api.js
@@ -730,3 +730,19 @@ test('using --match with no matching tests causes an AvaError to be emitted', fu
 
 	return api.run([path.join(__dirname, 'fixture/match-no-match.js')]);
 });
+
+test('errors thrown when running files are emitted', function (t) {
+	t.plan(2);
+
+	var api = new Api();
+
+	api.on('error', function (err) {
+		t.is(err.name, 'SyntaxError');
+		t.match(err.message, /Unexpected token/);
+	});
+
+	return api.run([
+		path.join(__dirname, 'fixture/es2015.js'),
+		path.join(__dirname, 'fixture/syntax-error.js')
+	]);
+});

--- a/test/fixture/syntax-error.js
+++ b/test/fixture/syntax-error.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test.(t => {
+	t.pass();
+});


### PR DESCRIPTION
Fixes #622.

Catch exceptions when initially running files. Don't run any tests, just report the exception.

Move test teardown into a callback for the run promise so it can be used when `--match` is used but there are no matches, and when exceptions occur while initially running files.

Teardown causes the test promise to reject, which leads to an attempt to run the tests. Add a guard to prevent this.

