### PR TITLE
Docs : fix typo readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,7 @@ See the [ES2015 support](#es2015-support) section for details on the `babel` opt
 
 ## Documentation
 
-Tests are run concurrently. You can specify synchronous and asynchronous tests. Tests are considered synchronous unless you return a promise or [observable](https://github.com/zenparsing/zen-observable)).
+Tests are run concurrently. You can specify synchronous and asynchronous tests. Tests are considered synchronous unless you return a promise or [observable](https://github.com/zenparsing/zen-observable).
 
 We *highly* recommend the use of [async functions](#async-function-support). They make asynchronous code concise and readable, and they implicitly return a promise so you don't have to.
 


### PR DESCRIPTION
Two parentheses instead of one.

