### PR TITLE
fix index.d.ts for noImplicitAny option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -129,11 +129,13 @@ export interface AssertContext {
 	 * Assert that function throws an error or promise rejects.
 	 * @param error Can be a constructor, regex, error message or validation function.
 	 */
-	throws(value: (() => void) | Promise<{}>, error?: ErrorValidator, message?: string);
+	throws(value: Promise<{}>, error?: ErrorValidator, message?: string): Promise<any>;
+	throws(value: () => void, error?: ErrorValidator, message?: string): any;
 	/**
 	 * Assert that function doesn't throw an error or promise resolves.
 	 */
-	notThrows(value: (() => void) | Promise<{}>, message?: string);
+	notThrows<U>(value: Promise<U>, message?: string): Promise<U>;
+	notThrows(value: () => void, message?: string): void;
 	/**
 	 * Assert that contents matches regex.
 	 */


### PR DESCRIPTION
```
$ $(npm bin)/tsc --noImplicitAny
node_modules/ava/index.d.ts(132,2): error TS7010: 'throws', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/ava/index.d.ts(136,2): error TS7010: 'notThrows', which lacks return-type annotation, implicitly has an 'any' return type.
```