### PR TITLE
Truncate mini reporter titles

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -76,9 +76,7 @@ MiniReporter.prototype.prefix = function (str) {
 };
 
 MiniReporter.prototype._test = function (test) {
-	var title = test.title;
-
-	title = cliTruncate(title, process.stdout.columns - 3);
+	var title = cliTruncate(test.title, process.stdout.columns - 3);
 
 	if (test.todo) {
 		this.todoCount++;

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -78,9 +78,7 @@ MiniReporter.prototype.prefix = function (str) {
 MiniReporter.prototype._test = function (test) {
 	var title = test.title;
 
-	if (title.length > process.stdout.columns) {
-		title = cliTruncate(title, process.stdout.columns - 3);
-	}
+	title = cliTruncate(title, process.stdout.columns - 3);
 
 	if (test.todo) {
 		this.todoCount++;

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -6,6 +6,7 @@ var plur = require('plur');
 var spinners = require('cli-spinners');
 var chalk = require('chalk');
 var colors = require('../colors');
+var cliTruncate = require('cli-truncate');
 
 chalk.enabled = true;
 Object.keys(colors).forEach(function (key) {
@@ -76,6 +77,10 @@ MiniReporter.prototype.prefix = function (str) {
 
 MiniReporter.prototype._test = function (test) {
 	var title = test.title;
+
+	if (title.length > process.stdout.columns) {
+		title = cliTruncate(title, process.stdout.columns - 3);
+	}
 
 	if (test.todo) {
 		this.todoCount++;

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "chalk": "^1.0.0",
     "cli-cursor": "^1.0.2",
     "cli-spinners": "^0.1.2",
+    "cli-truncate": "^0.1.0",
     "co-with-promise": "^4.6.0",
     "common-path-prefix": "^1.0.0",
     "convert-source-map": "^1.1.2",

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -8,6 +8,7 @@ var beautifyStack = require('../../lib/beautify-stack');
 chalk.enabled = true;
 
 var graySpinner = chalk.gray.dim('⠋');
+process.stdout.columns = 5000;
 
 function miniReporter() {
 	var reporter = _miniReporter();

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -8,6 +8,9 @@ var beautifyStack = require('../../lib/beautify-stack');
 chalk.enabled = true;
 
 var graySpinner = chalk.gray.dim('⠋');
+
+// Needed because tap doesn't emulate a tty environment and thus this is
+// undefined, making `cli-truncate` append '...' to test titles
 process.stdout.columns = 5000;
 
 function miniReporter() {


### PR DESCRIPTION
This fixes #629.

Here's how testing `got` looks like:

![](http://i.imgur.com/160bwFF.gif)

I just use Sindre's [cli-truncate](https://github.com/sindresorhus/cli-truncate) to truncate the test title if it's  longer than the CLI columns. I think truncating to the column size minus 3 looks nice, but open to change.