### PR TITLE
Fix run crashes

### DIFF
--- a/api.js
+++ b/api.js
@@ -244,6 +244,7 @@ Api.prototype.run = function (files, options) {
 					var tried = false;
 					function tryRun() {
 						if (!tried && !bailed) {
+							tried = true;
 							unreportedFiles--;
 							if (unreportedFiles === 0) {
 								run();

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -5,7 +5,7 @@ var objectAssign = require('object-assign');
 var Promise = require('bluebird');
 var debug = require('debug')('ava');
 var AvaError = require('./ava-error');
-var send = require('./send');
+var doSend = require('./send');
 
 var env = process.env;
 
@@ -37,6 +37,16 @@ module.exports = function (file, opts) {
 	});
 
 	var relFile = path.relative('.', file);
+
+	var exiting = false;
+	var send = function (ps, name, data) {
+		if (!exiting) {
+			// This seems to trigger a Node bug which kills the AVA master process, at
+			// least while running AVA's tests. See
+			// <https://github.com/novemberborn/_ava-tap-crash> for more details.
+			doSend(ps, name, data);
+		}
+	};
 
 	var promise = new Promise(function (resolve, reject) {
 		ps.on('error', reject);
@@ -96,6 +106,7 @@ module.exports = function (file, opts) {
 	// teardown finished, now exit
 	ps.on('teardown', function () {
 		send(ps, 'exit');
+		exiting = true;
 	});
 
 	// uncaught exception in fork, need to exit


### PR DESCRIPTION
Fixes CI failures like <https://travis-ci.org/sindresorhus/ava/jobs/115088398>. See <https://github.com/novemberborn/_ava-tap-crash> for background.