### PR TITLE
Don't log skip/todo tests in mini reporter

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -65,6 +65,20 @@ MiniReporter.prototype.clearInterval = function () {
 };
 
 MiniReporter.prototype.test = function (test) {
+	if (test.todo) {
+		this.todoCount++;
+	} else if (test.skip) {
+		this.skipCount++;
+	} else if (test.error) {
+		this.failCount++;
+	} else {
+		this.passCount++;
+	}
+
+	if (test.todo || test.skip) {
+		return;
+	}
+
 	return this.prefix(this._test(test));
 };
 
@@ -80,15 +94,8 @@ MiniReporter.prototype._test = function (test) {
 	var PADDING = 1;
 	var title = cliTruncate(test.title, process.stdout.columns - SPINNER_WIDTH - PADDING);
 
-	if (test.todo) {
-		this.todoCount++;
-	} else if (test.skip) {
-		this.skipCount++;
-	} else if (test.error) {
+	if (test.error) {
 		title = colors.error(test.title);
-		this.failCount++;
-	} else {
-		this.passCount++;
 	}
 
 	return title + '\n' + this.reportCounts();
@@ -109,16 +116,16 @@ MiniReporter.prototype.reportCounts = function () {
 		status += '\n   ' + colors.pass(this.passCount, 'passed');
 	}
 
+	if (this.failCount > 0) {
+		status += '\n   ' + colors.error(this.failCount, 'failed');
+	}
+
 	if (this.skipCount > 0) {
 		status += '\n   ' + colors.skip(this.skipCount, 'skipped');
 	}
 
 	if (this.todoCount > 0) {
 		status += '\n   ' + colors.todo(this.todoCount, 'todo');
-	}
-
-	if (this.failCount > 0) {
-		status += '\n   ' + colors.error(this.failCount, 'failed');
 	}
 
 	return status.length ? status : '\n';

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -121,39 +121,25 @@ test('failing test after passing', function (t) {
 test('skipped test', function (t) {
 	var reporter = miniReporter();
 
-	var actualOutput = reporter.test({
+	var output = reporter.test({
 		title: 'skipped',
 		skip: true
 	});
 
-	var expectedOutput = [
-		' ',
-		' ' + graySpinner + ' skipped',
-		'',
-		'   ' + chalk.yellow('1 skipped')
-	].join('\n');
-
-	t.is(actualOutput, expectedOutput);
+	t.false(output);
 	t.end();
 });
 
 test('todo test', function (t) {
 	var reporter = miniReporter();
 
-	var actualOutput = reporter.test({
+	var output = reporter.test({
 		title: 'todo',
 		skip: true,
 		todo: true
 	});
 
-	var expectedOutput = [
-		' ',
-		' ' + graySpinner + ' todo',
-		'',
-		'   ' + chalk.blue('1 todo')
-	].join('\n');
-
-	t.is(actualOutput, expectedOutput);
+	t.false(output);
 	t.end();
 });
 


### PR DESCRIPTION
This PR fixes #628.

Mini reporter now shows skipped/todo tests only at the final output with all the results.