### PR TITLE
Show error if babel config value is invalid

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,6 +23,7 @@ var arrify = require('arrify');
 var meow = require('meow');
 var Promise = require('bluebird');
 var pkgConf = require('pkg-conf');
+var chalk = require('chalk');
 var isCi = require('is-ci');
 var colors = require('./lib/colors');
 var verboseReporter = require('./lib/reporters/verbose');
@@ -40,6 +41,18 @@ var conf = pkgConf.sync('ava', {
 		babel: 'default'
 	}
 });
+
+// check for valid babel config shortcuts (can be either "default" or "inherit")
+var isValidShortcut = ['default', 'inherit'].indexOf(conf.babel) !== -1;
+
+if (!conf.babel || (typeof conf.babel === 'string' && !isValidShortcut)) {
+	var message = '';
+	message += 'Unexpected Babel configuration for AVA. ';
+	message += 'See ' + chalk.underline('https://github.com/sindresorhus/ava#es2015-support') + ' for allowed values.';
+
+	console.log('\n  ' + colors.error(figures.cross) + ' ' + message);
+	process.exit(1);
+}
 
 var cli = meow([
 	'Usage',

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,9 +4,15 @@ var childProcess = require('child_process');
 var test = require('tap').test;
 global.Promise = require('bluebird');
 var getStream = require('get-stream');
+var figures = require('figures');
 var arrify = require('arrify');
+var chalk = require('chalk');
 var touch = require('touch');
 var cliPath = path.join(__dirname, '../cli.js');
+
+// for some reason chalk is disabled by default
+chalk.enabled = true;
+var colors = require('../lib/colors');
 
 function execCli(args, opts, cb) {
 	var dirname;
@@ -57,6 +63,20 @@ function execCli(args, opts, cb) {
 
 	return child;
 }
+
+test('disallow invalid babel config shortcuts', function (t) {
+	execCli('es2015.js', {dirname: 'fixture/invalid-babel-config'}, function (err, stdout) {
+		t.ok(err);
+
+		var expectedOutput = '\n  ';
+		expectedOutput += colors.error(figures.cross) + ' Unexpected Babel configuration for AVA.';
+		expectedOutput += ' See ' + chalk.underline('https://github.com/sindresorhus/ava#es2015-support') + ' for allowed values.';
+		expectedOutput += '\n';
+
+		t.is(stdout, expectedOutput);
+		t.end();
+	});
+});
 
 test('throwing a named function will report the to the console', function (t) {
 	execCli('fixture/throw-named-function.js', function (err, stdout, stderr) {

--- a/test/fixture/invalid-babel-config/package.json
+++ b/test/fixture/invalid-babel-config/package.json
@@ -1,0 +1,5 @@
+{
+  "ava": {
+    "babel": "mafia"
+  }
+}


### PR DESCRIPTION
This PR fixes #623.

If `babel` config value is invalid, AVA now shows an error:

<img width="718" alt="screen shot 2016-03-15 at 8 57 27 pm" src="https://cloud.githubusercontent.com/assets/697676/13790342/a8664d36-eaf0-11e5-909e-ba3ca29916cd.png">
