### PR TITLE
Ensure t.throws() returns the error

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -277,31 +277,31 @@ function PublicApi(test) {
 }
 
 function onAssertionEvent(event) {
-	var promise = null;
-
 	if (event.assertionThrew) {
 		event.error.powerAssertContext = event.powerAssertContext;
 		event.error.originalMessage = event.originalMessage;
 		this._test._setAssertError(event.error);
-	} else {
-		var ret = event.returnValue;
-
-		if (isObservable(ret)) {
-			ret = observableToPromise(ret);
-		}
-
-		if (isPromise(ret)) {
-			promise = ret
-				.then(null, function (err) {
-					err.originalMessage = event.originalMessage;
-					throw err;
-				});
-		}
+		this._test._assert(null);
+		return null;
 	}
 
-	this._test._assert(promise);
+	var ret = event.returnValue;
 
-	return promise;
+	if (isObservable(ret)) {
+		ret = observableToPromise(ret);
+	}
+
+	if (isPromise(ret)) {
+		var promise = ret.then(null, function (err) {
+			err.originalMessage = event.originalMessage;
+			throw err;
+		});
+		this._test._assert(promise);
+		return promise;
+	}
+
+	this._test._assert(null);
+	return ret;
 }
 
 PublicApi.prototype = enhanceAssert({

--- a/test/test.js
+++ b/test/test.js
@@ -205,26 +205,31 @@ test('handle falsy testing of objects', function (t) {
 });
 
 test('handle throws with error', function (t) {
+	var expected = new Error('foo');
+	var actual;
 	var result = ava(function (a) {
-		a.throws(function () {
-			throw new Error('foo');
+		actual = a.throws(function () {
+			throw expected;
 		});
 	}).run();
 
 	t.is(result.passed, true);
 	t.is(result.result.assertCount, 1);
+	t.is(actual, expected);
 	t.end();
 });
 
 test('handle throws without error', function (t) {
+	var actual;
 	var result = ava(function (a) {
-		a.throws(function () {
+		actual = a.throws(function () {
 			return;
 		});
 	}).run();
 
 	t.is(result.passed, false);
 	t.ok(result.reason);
+	t.is(actual, null);
 	t.end();
 });
 


### PR DESCRIPTION
PR #576 changed the `t.throws()` assertion to return the thrown error, or if asynchronous a promise for the rejection reason. Unfortunately this only worked for asynchronous errors.

The tests cover the changes in `lib/assert.js` but `t.throws()` is an *enhanced* assertion. This commit ensures any values returned from `lib/assert.js` assertions are indeed returned by the corresponding `t.` assertions.