### PR TITLE
fix default AVA's Babel configuration in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -538,7 +538,7 @@ The corresponding Babel config for AVA's setup is as follows:
 {
   "presets": [
     "es2015",
-    "stage-0",
+    "stage-2",
   ],
   "plugins": [
     "espower",


### PR DESCRIPTION
Hello everybody :smiley:!

This is really a minimal fix but I noticed, while working on https://github.com/babel/babel.github.io/pull/758, that in the `readme.md`, the AVA's default Babel configuration is incorrect: it includes the `"stage-0"` preset in place of the `"stage-2"` preset stated just few lines above and also [here](https://github.com/sindresorhus/ava/blob/6d5f3225cc712f10e7a0a8a9c6e40d574fd4b251/package.json#L85).

Again, it's just a super minor fix, but it can lead to possible problems if you cut-and-paste the default configuration.

Thanks :smile:!

