### PR TITLE
hotfix: inline source maps

### DIFF
--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -44,7 +44,7 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 		objectAssign(options, {
 			inputSourceMap: sourceMap && sourceMap.toObject(),
 			filename: filename,
-			sourceMaps: true,
+			sourceMaps: 'both',
 			ast: false
 		});
 


### PR DESCRIPTION
Wait to merge - this might not be the best way to fix the issue.

This fixes an `nyc` compatibility issue that [surfaced here](https://github.com/kentcdodds/react-ava-workshop/pull/5)

I am not entirely sure why source-map inlining is required (it worked fine without it in previous versions of AVA).

@novemberborn - It looks like the type of value we return from `retrieveSourceMap` inside `test-worker.js` changed from an object to a string sometime between `0.9.2` and `0.13` - I wonder if that has something to do with it.