### PR TITLE
update typescript recipe

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -18,7 +18,7 @@ Create a [`tsconfig.json`](https://github.com/Microsoft/TypeScript/wiki/tsconfig
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2015"
+		"target": "ES6"
 	}
 }
 ```


### PR DESCRIPTION
This updates the recipe to use the proper 'target'. es2015 was incorrect according
to the documentation: https://github.com/Microsoft/TypeScript/wiki/Compiler-Options