### PR TITLE
Print the planned and actual assertion count when incorrect.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -7,6 +7,7 @@ var co = require('co-with-promise');
 var observableToPromise = require('observable-to-promise');
 var isPromise = require('is-promise');
 var isObservable = require('is-observable');
+var plur = require('plur');
 var inspect = require('util').inspect;
 var assert = require('./assert');
 var enhanceAssert = require('./enhance-assert');
@@ -223,7 +224,7 @@ Test.prototype._checkPlanCount = function () {
 		this._setAssertError(new assert.AssertionError({
 			actual: this.assertions.length,
 			expected: this.planCount,
-			message: 'Assertion count does not match planned',
+			message: 'Planned for ' + this.planCount + plur(' assertion', this.planCount) + ', but got ' + this.assertions.length + '.',
 			operator: 'plan'
 		}));
 

--- a/test/test.js
+++ b/test/test.js
@@ -103,7 +103,7 @@ test('run more assertions than planned', function (t) {
 	t.is(result.reason.name, 'AssertionError');
 	t.is(result.reason.expected, 2);
 	t.is(result.reason.actual, 3);
-	t.match(result.reason.message, /count does not match planned/);
+	t.match(result.reason.message, /Planned for 2 assertions, but got 3\./);
 	t.end();
 });
 


### PR DESCRIPTION
Fixes #102

The assertion error already had `expected` and `actual` properties, but only the tap reporter displays those. Instead of modifying existing reporters to handle the special case of planned assertions, I took the easy way out and just dynamically generated the error message.