### PR TITLE
Ensure overridden babel config plugins array is immutable 

### DIFF
--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -50,8 +50,7 @@ CachingPrecompiler.prototype._factory = function (babelConfig, cacheDir) {
 			ast: false
 		});
 
-		options.plugins = options.plugins || [];
-		options.plugins.push(powerAssert, transformRuntime, rewriteRuntime);
+		options.plugins = (options.plugins || []).concat([powerAssert, transformRuntime, rewriteRuntime]);
 
 		return options;
 	}


### PR DESCRIPTION
Since `babelConfig` in the CachingPrecompiler.prototype._factory method was a JavaScript object coming from an external source, the .push was altering the array in place. objectAssign is shallow so the plugins were being mutated, ensuring that AVA's required plugins were continually appending for each file loaded and parsed.

Using .concat ensures the original plugins array is not mutated and thus doesn't collect plugins like a hoarder.

Does not solve #674 however it was noticed during an attempt to address that issue.