### PR TITLE
Reject test runs when forks exit with an unexpected signal

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -79,7 +79,7 @@ module.exports = function (file, opts) {
 		});
 
 		ps.on('exit', function (code) {
-			if (code > 0 && code !== 143) {
+			if (code > 0) {
 				return reject(new AvaError(relFile + ' exited with a non-zero exit code: ' + code));
 			}
 

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -78,9 +78,13 @@ module.exports = function (file, opts) {
 			send(ps, 'teardown');
 		});
 
-		ps.on('exit', function (code) {
+		ps.on('exit', function (code, signal) {
 			if (code > 0) {
 				return reject(new AvaError(relFile + ' exited with a non-zero exit code: ' + code));
+			}
+
+			if (code === null && signal) {
+				return reject(new AvaError(relFile + ' exited due to ' + signal));
 			}
 
 			if (results) {

--- a/test/fixture/immediate-3-exit.js
+++ b/test/fixture/immediate-3-exit.js
@@ -1,0 +1,1 @@
+process.exit(3);

--- a/test/fork.js
+++ b/test/fork.js
@@ -60,6 +60,22 @@ test('exit after tests are finished', function (t) {
 		});
 });
 
+test('rejects promise if the process exits with a non-zero code', function (t) {
+	return fork(fixture('immediate-3-exit.js'))
+		.catch(function (err) {
+			t.is(err.name, 'AvaError');
+			t.is(err.message, path.join('test', 'fixture', 'immediate-3-exit.js') + ' exited with a non-zero exit code: 3');
+		});
+});
+
+test('rejects promise if the process exits without results', function (t) {
+	return fork(fixture('immediate-0-exit.js'))
+		.catch(function (err) {
+			t.is(err.name, 'AvaError');
+			t.is(err.message, 'Test results were not received from ' + path.join('test', 'fixture', 'immediate-0-exit.js'));
+		});
+});
+
 test('fake timers do not break duration', function (t) {
 	fork(fixture('fake-timers.js'))
 		.run({})

--- a/test/fork.js
+++ b/test/fork.js
@@ -76,6 +76,18 @@ test('rejects promise if the process exits without results', function (t) {
 		});
 });
 
+test('rejects promise if the process is killed', function (t) {
+	var forked = fork(fixture('es2015.js'));
+	return forked
+		.on('stats', function () {
+			this.kill('SIGKILL');
+		})
+		.catch(function (err) {
+			t.is(err.name, 'AvaError');
+			t.is(err.message, path.join('test', 'fixture', 'es2015.js') + ' exited due to SIGKILL');
+		});
+});
+
 test('fake timers do not break duration', function (t) {
 	fork(fixture('fake-timers.js'))
 		.run({})


### PR DESCRIPTION
As discovered in #604 child processes can be killed by outside parties. In this case there is no exit code, though a signal is present. With this PR test runs are rejected with an appropriate error message, rather than the misleading "no test results received" message.

I've also cleaned up now redundant Node 0.10 SIGTERM handling (#155) and added a test for the existing test run rejection behavior.