### PR TITLE
show error message if literal is thrown - fixes #661

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -94,13 +94,18 @@ x.throws = function (fn, err, msg) {
 
 		var result;
 
-		assert.throws(function () {
-			try {
-				fn();
-			} catch (error) {
-				result = error;
-				throw error;
+		try {
+			fn();
+		} catch (error) {
+			if (error && typeof error !== 'object') {
+				throw new TypeError('Expected an object to be thrown.');
 			}
+
+			result = error;
+		}
+
+		assert.throws(function () {
+			throw result;
 		}, err, msg);
 
 		return result;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -98,7 +98,10 @@ x.throws = function (fn, err, msg) {
 			fn();
 		} catch (error) {
 			if (error && typeof error !== 'object') {
-				throw new TypeError('Expected an object to be thrown.');
+				var e = new TypeError('Error `' + error + '` is not of type `object` but of type `' + (typeof error) + '`.');
+				e.actual = typeof error;
+				e.expected = 'object';
+				throw e;
 			}
 
 			result = error;

--- a/test/test.js
+++ b/test/test.js
@@ -433,6 +433,40 @@ test('throws and notThrows work with promises', function (t) {
 	});
 });
 
+test('throws does not work with literals', function (t) {
+	var result = ava(function (a) {
+		a.plan(2);
+		a.throws(function () {
+			// eslint-disable-next-line
+			throw 'foo';
+		});
+
+		a.throws(function () {
+			// eslint-disable-next-line
+			throw 5;
+		});
+	}).run();
+
+	t.is(result.reason.message, 'Expected an object to be thrown.');
+	t.is(result.passed, false);
+	t.is(result.result.planCount, 2);
+	t.is(result.result.assertCount, 2);
+	t.end();
+});
+
+test('throws does not work with promises rejecting literals', function (t) {
+	ava(function (a) {
+		a.plan(1);
+		a.throws(Promise.reject('foo'));
+	}).run().then(function (result) {
+		t.is(result.reason.message, 'Expected an object to be thrown.');
+		t.is(result.passed, false);
+		t.is(result.result.planCount, 1);
+		t.is(result.result.assertCount, 1);
+		t.end();
+	});
+});
+
 test('waits for t.throws to resolve after t.end is called', function (t) {
 	ava.cb(function (a) {
 		a.plan(1);

--- a/test/test.js
+++ b/test/test.js
@@ -447,8 +447,10 @@ test('throws does not work with literals', function (t) {
 		});
 	}).run();
 
-	t.is(result.reason.message, 'Expected an object to be thrown.');
 	t.is(result.passed, false);
+	t.is(result.reason.message, 'Error `foo` is not of type `object` but of type `string`.');
+	t.is(result.reason.actual, 'string');
+	t.is(result.reason.expected, 'object');
 	t.is(result.result.planCount, 2);
 	t.is(result.result.assertCount, 2);
 	t.end();
@@ -457,10 +459,12 @@ test('throws does not work with literals', function (t) {
 test('throws does not work with promises rejecting literals', function (t) {
 	ava(function (a) {
 		a.plan(1);
-		a.throws(Promise.reject('foo'));
+		a.throws(Promise.reject(5));
 	}).run().then(function (result) {
-		t.is(result.reason.message, 'Expected an object to be thrown.');
 		t.is(result.passed, false);
+		t.is(result.reason.message, 'Error `5` is not of type `object` but of type `number`.');
+		t.is(result.reason.actual, 'number');
+		t.is(result.reason.expected, 'object');
 		t.is(result.result.planCount, 1);
 		t.is(result.result.assertCount, 1);
 		t.end();


### PR DESCRIPTION
This PR fixes #661 which prints `Expected an object to be thrown.`. It's the same error message that ESLint shows when trying to throw a literal. Feel free to provide feedback of any kind.
