### PR TITLE
(2) show error message if literal is thrown - fixes #661

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -4,6 +4,7 @@ var deepEqual = require('only-shallow');
 var observableToPromise = require('observable-to-promise');
 var isObservable = require('is-observable');
 var isPromise = require('is-promise');
+var isError = require('is-error');
 var util = require('util');
 var x = module.exports;
 
@@ -103,8 +104,21 @@ x.throws = function (fn, err, msg) {
 			}
 		}, err, msg);
 
+		if (!isError(result)) {
+			throw result;
+		}
+
 		return result;
 	} catch (err) {
+		if (!isError(err)) {
+			var actual = Object.prototype.toString.call(err);
+			var expected = '[object Error]';
+			var message = 'Error `' + err + '` is not of type `' + expected + '` but of type `' + actual + '`.';
+
+			test(false, create(actual, expected, undefined, message, x.throws));
+			return;
+		}
+
 		test(false, create(err.actual, err.expected, err.operator, err.message, x.throws));
 	}
 };

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "globby": "^4.0.0",
     "ignore-by-default": "^1.0.0",
     "is-ci": "^1.0.7",
+    "is-error": "^2.2.0",
     "is-generator-fn": "^1.0.0",
     "is-obj": "^1.0.0",
     "is-observable": "^0.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -433,6 +433,44 @@ test('throws and notThrows work with promises', function (t) {
 	});
 });
 
+test('throws does not work with literals', function (t) {
+	var result = ava(function (a) {
+		a.plan(2);
+		a.throws(function () {
+			// eslint-disable-next-line
+			throw 'foo';
+		});
+
+		a.throws(function () {
+			// eslint-disable-next-line
+			throw 5;
+		});
+	}).run();
+
+	t.is(result.passed, false);
+	t.is(result.reason.message, 'Error `foo` is not of type `[object Error]` but of type `[object String]`.');
+	t.is(result.reason.actual, '[object String]');
+	t.is(result.reason.expected, '[object Error]');
+	t.is(result.result.planCount, 2);
+	t.is(result.result.assertCount, 2);
+	t.end();
+});
+
+test('throws does not work with promises rejecting literals', function (t) {
+	ava(function (a) {
+		a.plan(1);
+		a.throws(Promise.reject(5));
+	}).run().then(function (result) {
+		t.is(result.passed, false);
+		t.is(result.reason.message, 'Error `5` is not of type `[object Error]` but of type `[object Number]`.');
+		t.is(result.reason.actual, '[object Number]');
+		t.is(result.reason.expected, '[object Error]');
+		t.is(result.result.planCount, 1);
+		t.is(result.result.assertCount, 1);
+		t.end();
+	});
+});
+
 test('waits for t.throws to resolve after t.end is called', function (t) {
 	ava.cb(function (a) {
 		a.plan(1);


### PR DESCRIPTION
This is another approach (see #683) in order to resolve #661. The error messages are a little bit different now as well

> Error `foo` is not of type `[object Error]` but of type `[object String]`.

instead of 

> Error `foo` is not of type `object` but of type `string`.

To prevent the case where someone does `throw {foo: 'bar'}` which will end up in the message

> Error `{foo: 'bar'}` is not of type `object` but of type `object`.

// @novemberborn @jamestalmage @sindresorhus 


