### PR TITLE
throw error if required dependency could not be found - fixes #691

### DIFF
--- a/api.js
+++ b/api.js
@@ -28,8 +28,15 @@ function Api(options) {
 	EventEmitter.call(this);
 
 	this.options = options || {};
-	this.options.require = (this.options.require || []).map(resolveCwd);
 	this.options.match = this.options.match || [];
+	this.options.require = (this.options.require || []).map(function (moduleId) {
+		var ret = resolveCwd(moduleId);
+		if (ret === null) {
+			throw new Error('Could not resolve required module \'' + moduleId + '\'');
+		}
+
+		return ret;
+	});
 
 	this.excludePatterns = [
 		'!**/node_modules/**',

--- a/test/api.js
+++ b/test/api.js
@@ -533,6 +533,15 @@ test('Node.js-style --require CLI argument', function (t) {
 		});
 });
 
+test('Node.js-style --require CLI argument module not found', function (t) {
+	t.plan(1);
+
+	t.throws(function () {
+		/* eslint no-new: 0 */
+		new Api({require: ['foo-bar']});
+	}, /^Could not resolve required module 'foo-bar'$/);
+});
+
 test('power-assert support', function (t) {
 	t.plan(3);
 


### PR DESCRIPTION
This PR fixes #691 by throwing an error if `resolve-cwd` returns `null`.