### PR TITLE
Add test-like output when test file does not exist

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -7,6 +7,7 @@ var spinners = require('cli-spinners');
 var chalk = require('chalk');
 var cliTruncate = require('cli-truncate');
 var colors = require('../colors');
+var cross = require('figures').cross;
 
 chalk.enabled = true;
 Object.keys(colors).forEach(function (key) {
@@ -131,7 +132,7 @@ MiniReporter.prototype.reportCounts = function () {
 		status += '\n   ' + colors.todo(this.todoCount, 'todo');
 	}
 
-	return status.length ? status : '\n';
+	return status.length ? status : '';
 };
 
 MiniReporter.prototype.finish = function () {
@@ -180,7 +181,7 @@ MiniReporter.prototype.finish = function () {
 			i++;
 
 			if (err.type === 'exception' && err.name === 'AvaError') {
-				status += '\n\n  ' + colors.error(i + '. ' + err.message) + '\n';
+				status += '\n\n  ' + colors.error(cross + ' ' + err.message) + '\n';
 			} else {
 				var title = err.type === 'rejection' ? 'Unhandled Rejection' : 'Uncaught Exception';
 				var description = err.stack ? err.stack : JSON.stringify(err);
@@ -200,7 +201,7 @@ MiniReporter.prototype.finish = function () {
 
 MiniReporter.prototype.write = function (str) {
 	cliCursor.hide();
-	this.currentStatus = str + '\n';
+	this.currentStatus = String(str);
 	this._update();
 	this.statusLineCount = this.currentStatus.split('\n').length;
 };

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -132,7 +132,7 @@ MiniReporter.prototype.reportCounts = function () {
 		status += '\n   ' + colors.todo(this.todoCount, 'todo');
 	}
 
-	return status.length ? status : '';
+	return status;
 };
 
 MiniReporter.prototype.finish = function () {
@@ -201,7 +201,7 @@ MiniReporter.prototype.finish = function () {
 
 MiniReporter.prototype.write = function (str) {
 	cliCursor.hide();
-	this.currentStatus = String(str);
+	this.currentStatus = str;
 	this._update();
 	this.statusLineCount = this.currentStatus.split('\n').length;
 };

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -4,6 +4,7 @@ var test = require('tap').test;
 var AvaError = require('../../lib/ava-error');
 var _miniReporter = require('../../lib/reporters/mini');
 var beautifyStack = require('../../lib/beautify-stack');
+var cross = require('figures').cross;
 
 chalk.enabled = true;
 
@@ -255,7 +256,7 @@ test('results with passing tests and exceptions', function (t) {
 	t.match(output[5], /Error: failure/);
 	t.match(output[6], /test\/reporters\/mini\.js/);
 	var next = 6 + output.slice(6).indexOf('') + 1;
-	t.is(output[next], '  ' + chalk.red('2. A futuristic test runner'));
+	t.is(output[next], '  ' + chalk.red(cross + ' A futuristic test runner'));
 	t.end();
 });
 
@@ -291,6 +292,6 @@ test('empty results after reset', function (t) {
 	reporter.reset();
 
 	var output = reporter.finish();
-	t.is(output, '\n\n');
+	t.is(output, '\n');
 	t.end();
 });


### PR DESCRIPTION
This helps with #575. Kinda.

First as @novemberborn said:

> If we can agree that these are not fatal errors then I think we can fix up the reporters.

But if we agree to do them in the reporters, I fixed up the extraneous new lines and added a cross for `AvaError` type of exceptions.

Here's how test on a nonexistent file and a regular one looks like:

<img width="810" alt="screen shot 2016-04-03 at 8 08 08 pm" src="https://cloud.githubusercontent.com/assets/8217766/14235882/beab456e-f9d8-11e5-92e2-e19773fda707.png">

Also there are a lot of places I could've chosen to remove newlines from, so tell me if there are any better ones (I did this quickly to see what you guys think!).