### PR TITLE
add tests that demonstrate various ways to use babel config.

### DIFF
--- a/test/fixture/babel-plugin-foo-to-bar.js
+++ b/test/fixture/babel-plugin-foo-to-bar.js
@@ -1,0 +1,19 @@
+module.exports = function (babel) {
+	var t = babel.types;
+
+	return {
+		visitor: {
+			CallExpression: function (path) {
+				// skip require calls
+				var firstArg = path.get('arguments')[0];
+				if (!isRequire(path) && firstArg && firstArg.isStringLiteral() && /foo/i.test(firstArg.node.value)) {
+					firstArg.replaceWith(t.stringLiteral(firstArg.node.value.replace('foo', 'bar').replace('FOO', 'BAR')));
+				}
+			}
+		}
+	};
+};
+
+function isRequire(path) {
+	return path.isCallExpression() && path.get('callee').isIdentifier() && (path.get('callee').node.name === 'require');
+}

--- a/test/fixture/babel-plugin-test-capitalizer.js
+++ b/test/fixture/babel-plugin-test-capitalizer.js
@@ -1,0 +1,19 @@
+module.exports = function (babel) {
+	var t = babel.types;
+
+	return {
+		visitor: {
+			CallExpression: function (path) {
+				// skip require calls
+				var firstArg = path.get('arguments')[0];
+				if (!isRequire(path) && firstArg && firstArg.isStringLiteral() && !/repeated test/.test(firstArg.node.value)) {
+					firstArg.replaceWith(t.stringLiteral(firstArg.node.value.toUpperCase()));
+				}
+			}
+		}
+	};
+};
+
+function isRequire(path) {
+	return path.isCallExpression() && path.get('callee').isIdentifier() && (path.get('callee').node.name === 'require');
+}

--- a/test/fixture/babelrc/.alt-babelrc
+++ b/test/fixture/babelrc/.alt-babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "stage-2"],
+  "plugins": ["../babel-plugin-foo-to-bar"]
+}

--- a/test/fixture/babelrc/.babelrc
+++ b/test/fixture/babelrc/.babelrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["this-plugin-does-not-exist"]
+  "presets": ["es2015", "stage-2"],
+  "plugins": ["../babel-plugin-test-doubler"]
 }

--- a/test/fixture/babelrc/test.js
+++ b/test/fixture/babelrc/test.js
@@ -1,3 +1,3 @@
 import test from '../../../'
 
-test(t => t.pass());
+test('foo', t => t.pass());


### PR DESCRIPTION
Issue #448 was kept open, in part, because we wanted to enable an `extends` option.
What we are after is actually possible using existing babel options.

A separate PR with recipes is forthcoming.