### PR TITLE
rename `t.ok()` to `t.truthy()` and `t.notOk()` to `t.falsy()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,9 +96,17 @@ export interface AssertContext {
 	/**
 	 * Assert that value is truthy.
 	 */
-	ok(value: any, message?: string): void;
+	truthy(value: any, message?: string): void;
 	/**
 	 * Assert that value is falsy.
+	 */
+	falsy(value: any, message?: string): void;
+	/**
+	 * DEPRECATED, use `truthy`. Assert that value is truthy.
+	 */
+	ok(value: any, message?: string): void;
+	/**
+	 * DEPRECATED, use `falsy`. Assert that value is falsy.
 	 */
 	notOk(value: any, message?: string): void;
 	/**

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -36,12 +36,12 @@ x.fail = function (msg) {
 	test(false, create(false, false, 'fail', msg, x.fail));
 };
 
-x.ok = function (val, msg) {
-	test(val, create(val, true, '==', msg, x.ok));
+x.truthy = function (val, msg) {
+	test(val, create(val, true, '==', msg, x.truthy));
 };
 
-x.notOk = function (val, msg) {
-	test(!val, create(val, false, '==', msg, x.notOk));
+x.falsy = function (val, msg) {
+	test(!val, create(val, false, '==', msg, x.falsy));
 };
 
 x.true = function (val, msg) {
@@ -142,6 +142,8 @@ x.ifError = x.error = function (err, msg) {
  * deprecated APIs
  */
 x.doesNotThrow = util.deprecate(x.notThrows, getDeprecationNotice('doesNotThrow()', 'notThrows()'));
+x.ok = util.deprecate(x.truthy, getDeprecationNotice('ok()', 'truthy()'));
+x.notOk = util.deprecate(x.falsy, getDeprecationNotice('notOk()', 'falsy()'));
 x.same = util.deprecate(x.deepEqual, getDeprecationNotice('same()', 'deepEqual()'));
 x.notSame = util.deprecate(x.notDeepEqual, getDeprecationNotice('notSame()', 'notDeepEqual()'));
 

--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -2,8 +2,8 @@ module.exports = enhanceAssert;
 module.exports.formatter = formatter;
 
 module.exports.PATTERNS = [
-	't.ok(value, [message])',
-	't.notOk(value, [message])',
+	't.truthy(value, [message])',
+	't.falsy(value, [message])',
 	't.true(value, [message])',
 	't.false(value, [message])',
 	't.is(value, expected, [message])',
@@ -12,6 +12,8 @@ module.exports.PATTERNS = [
 	't.notDeepEqual(value, expected, [message])',
 	't.regex(contents, regex, [message])',
 	// deprecated apis
+	't.ok(value, [message])',
+	't.notOk(value, [message])',
 	't.same(value, expected, [message])',
 	't.notSame(value, expected, [message])'
 ];

--- a/readme.md
+++ b/readme.md
@@ -830,7 +830,7 @@ const c = 'baz';
 require('assert').ok(a.test(b) || b === c);
 ```
 
-If you paste that into a Node REPL it'l return:
+If you paste that into a Node REPL it'll return:
 
 ```
 AssertionError: false == true

--- a/readme.md
+++ b/readme.md
@@ -851,8 +851,8 @@ Will output:
 
 ```
 t.true(a.test(b) || b === c)
-       |    |     |     |
-       |    "bar" "bar" "baz"
+       |      |     |     |
+       |      "bar" "bar" "baz"
        false
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -843,14 +843,14 @@ test(t => {
 	const a = /foo/;
 	const b = 'bar';
 	const c = 'baz';
-	t.truthy(a.test(b) || b === c);
+	t.true(a.test(b) || b === c);
 });
 ```
 
 Will output:
 
 ```
-t.truthy(a.test(b) || b === c)
+t.true(a.test(b) || b === c)
        |    |     |     |
        |    "bar" "bar" "baz"
        false

--- a/readme.md
+++ b/readme.md
@@ -739,7 +739,7 @@ Assertions are mixed into the [execution object](#t) provided to each test callb
 
 ```js
 test(t => {
-	t.ok('unicorn'); // assertion
+	t.truthy('unicorn'); // assertion
 });
 ```
 
@@ -753,11 +753,11 @@ Passing assertion.
 
 Failing assertion.
 
-### `.ok(value, [message])`
+### `.truthy(value, [message])`
 
 Assert that `value` is truthy.
 
-### `.notOk(value, [message])`
+### `.falsy(value, [message])`
 
 Assert that `value` is falsy.
 
@@ -843,14 +843,14 @@ test(t => {
 	const a = /foo/;
 	const b = 'bar';
 	const c = 'baz';
-	t.ok(a.test(b) || b === c);
+	t.truthy(a.test(b) || b === c);
 });
 ```
 
 Will output:
 
 ```
-t.ok(a.test(b) || b === c)
+t.truthy(a.test(b) || b === c)
        |    |     |     |
        |    "bar" "bar" "baz"
        false

--- a/test/api.js
+++ b/test/api.js
@@ -553,12 +553,12 @@ test('power-assert support', function (t) {
 
 			t.match(
 				api.errors[0].error.message,
-				/t\.ok\(a === 'bar'\)\s*\n\s+\|\s*\n\s+"foo"/m
+				/t\.truthy\(a === 'bar'\)\s*\n\s+\|\s*\n\s+"foo"/m
 			);
 
 			t.match(
 				api.errors[1].error.message,
-				/with message\s+t\.ok\(a === 'foo', 'with message'\)\s*\n\s+\|\s*\n\s+"bar"/m
+				/with message\s+t\.truthy\(a === 'foo', 'with message'\)\s*\n\s+\|\s*\n\s+"bar"/m
 			);
 		});
 });

--- a/test/api.js
+++ b/test/api.js
@@ -553,12 +553,12 @@ test('power-assert support', function (t) {
 
 			t.match(
 				api.errors[0].error.message,
-				/t\.truthy\(a === 'bar'\)\s*\n\s+\|\s*\n\s+"foo"/m
+				/t\.true\(a === 'bar'\)\s*\n\s+\|\s*\n\s+"foo"/m
 			);
 
 			t.match(
 				api.errors[1].error.message,
-				/with message\s+t\.truthy\(a === 'foo', 'with message'\)\s*\n\s+\|\s*\n\s+"bar"/m
+				/with message\s+t\.true\(a === 'foo', 'with message'\)\s*\n\s+\|\s*\n\s+"bar"/m
 			);
 		});
 });

--- a/test/assert.js
+++ b/test/assert.js
@@ -19,29 +19,29 @@ test('.fail()', function (t) {
 	t.end();
 });
 
-test('.ok()', function (t) {
+test('.truthy()', function (t) {
 	t.throws(function () {
-		assert.ok(0);
-		assert.ok(false);
+		assert.truthy(0);
+		assert.truthy(false);
 	});
 
 	t.doesNotThrow(function () {
-		assert.ok(1);
-		assert.ok(true);
+		assert.truthy(1);
+		assert.truthy(true);
 	});
 
 	t.end();
 });
 
-test('.notOk()', function (t) {
+test('.falsy()', function (t) {
 	t.throws(function () {
-		assert.notOk(1);
-		assert.notOk(true);
+		assert.falsy(1);
+		assert.falsy(true);
 	});
 
 	t.doesNotThrow(function () {
-		assert.notOk(0);
-		assert.notOk(false);
+		assert.falsy(0);
+		assert.falsy(false);
 	});
 
 	t.end();

--- a/test/cli.js
+++ b/test/cli.js
@@ -120,7 +120,7 @@ test('throwing a anonymous function will report the function to the console', fu
 test('log failed tests', function (t) {
 	execCli('fixture/one-pass-one-fail.js', function (err, stdout, stderr) {
 		t.ok(err);
-		t.match(stderr, /false == true/);
+		t.match(stderr, /failed via t.fail\(\)/);
 		t.end();
 	});
 });

--- a/test/fixture/one-pass-one-fail.js
+++ b/test/fixture/one-pass-one-fail.js
@@ -1,9 +1,9 @@
 import test from '../../';
 
 test('this is a passing test', t => {
-	t.truthy(true);
+	t.pass();
 });
 
 test('this is a failing test', t => {
-	t.truthy(false);
+	t.fail();
 });

--- a/test/fixture/one-pass-one-fail.js
+++ b/test/fixture/one-pass-one-fail.js
@@ -1,9 +1,9 @@
 import test from '../../';
 
 test('this is a passing test', t => {
-	t.ok(true);
+	t.truthy(true);
 });
 
 test('this is a failing test', t => {
-	t.ok(false);
+	t.truthy(false);
 });

--- a/test/fixture/power-assert.js
+++ b/test/fixture/power-assert.js
@@ -3,11 +3,11 @@ import test from '../../';
 test.serial(t => {
 	const a = 'foo';
 
-	t.truthy(a === 'bar');
+	t.true(a === 'bar');
 });
 
 test.serial(t => {
 	const a = 'bar';
 
-	t.truthy(a === 'foo', 'with message');
+	t.true(a === 'foo', 'with message');
 });

--- a/test/fixture/power-assert.js
+++ b/test/fixture/power-assert.js
@@ -3,11 +3,11 @@ import test from '../../';
 test.serial(t => {
 	const a = 'foo';
 
-	t.ok(a === 'bar');
+	t.truthy(a === 'bar');
 });
 
 test.serial(t => {
 	const a = 'bar';
 
-	t.ok(a === 'foo', 'with message');
+	t.truthy(a === 'foo', 'with message');
 });

--- a/test/fixture/slow-exit.js
+++ b/test/fixture/slow-exit.js
@@ -20,7 +20,7 @@ test.cb('long running', t => {
 	}, {alwaysLast: true});
 
 	setTimeout(() => {
-		t.ok(true);
+		t.truthy(true);
 		t.end();
 	});
 

--- a/test/fixture/slow-exit.js
+++ b/test/fixture/slow-exit.js
@@ -20,7 +20,7 @@ test.cb('long running', t => {
 	}, {alwaysLast: true});
 
 	setTimeout(() => {
-		t.truthy(true);
+		t.pass();
 		t.end();
 	});
 


### PR DESCRIPTION
Pretty confident that this is ready to go.

![sloth-sparkle-FFV4J8uEtJKGQ](https://camo.githubusercontent.com/dd5ef28af3f0a012d4cc84831046ebdf5dee8823/68747470733a2f2f6d65646961302e67697068792e636f6d2f6d656469612f464656344a387545744a4b47512f67697068792e676966)