### PR TITLE
Don't modify configured babel plugins array

### DIFF
--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -109,8 +109,7 @@ CachingPrecompiler.prototype._buildOptions = function (filePath, code) {
 		ast: false
 	});
 
-	options.plugins = options.plugins || [];
-	options.plugins.push.apply(options.plugins, this.defaultPlugins);
+	options.plugins = (options.plugins || []).concat(this.defaultPlugins);
 
 	return options;
 };

--- a/test/caching-precompiler.js
+++ b/test/caching-precompiler.js
@@ -148,3 +148,14 @@ test('uses babelConfig for babel options when babelConfig is an object', functio
 	t.same(options.plugins, [customPlugin, powerAssert, rewrite, transformRuntime]);
 	t.end();
 });
+
+test('does not modify plugins array in babelConfig', function (t) {
+	var plugins = [];
+	var precompiler = new CachingPrecompiler(uniqueTempDir(), {
+		plugins: plugins
+	});
+
+	precompiler.precompileFile(fixture('es2015.js'));
+	t.same(plugins, []);
+	t.end();
+});


### PR DESCRIPTION
Reimplementation of #675 after recent changes, with an added test. Thanks to @dcousineau for finding the bug.