### PR TITLE
clean up stat collection in runner

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -47,6 +47,7 @@ function Runner(options) {
 	this._serial = options.serial;
 	this._match = options.match || [];
 	this._addTestResult = this._addTestResult.bind(this);
+	this._buildStats = this._buildStats.bind(this);
 }
 
 util.inherits(Runner, EventEmitter);
@@ -89,21 +90,6 @@ optionChain(chainableMethods, function (opts, title, fn) {
 
 Runner.prototype._addTestResult = function (result) {
 	var test = result.result;
-
-	if (test.metadata.type === 'test') {
-		this.stats.testCount++;
-
-		if (test.metadata.todo) {
-			this.stats.todoCount++;
-		} else if (test.metadata.skipped) {
-			this.stats.skipCount++;
-		}
-	}
-
-	if (!result.passed) {
-		this.stats.failCount++;
-	}
-
 	var props = {
 		duration: test.duration,
 		title: test.title,
@@ -155,25 +141,11 @@ Runner.prototype._buildStats = function () {
 };
 
 Runner.prototype.run = function (options) {
-	var self = this;
-
-	this.stats = {
-		failCount: 0,
-		passCount: 0,
-		skipCount: 0,
-		todoCount: 0,
-		testCount: 0
-	};
-
 	if (options.runOnlyExclusive && !this.tests.hasExclusive) {
-		return Promise.resolve();
+		return Promise.resolve(null);
 	}
 
 	this.tests.on('test', this._addTestResult);
 
-	return Promise.resolve(this.tests.build(this._bail).run()).then(function () {
-		self.stats = self._buildStats();
-
-		return self.stats;
-	});
+	return Promise.resolve(this.tests.build(this._bail).run()).then(this._buildStats);
 };

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -51,9 +51,9 @@ test('after', function (t) {
 		arr.push('a');
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.passCount, 1);
-		t.is(runner.stats.failCount, 0);
+	runner.run({}).then(function (stats) {
+		t.is(stats.passCount, 1);
+		t.is(stats.failCount, 0);
 		t.same(arr, ['a', 'b']);
 		t.end();
 	});
@@ -158,8 +158,8 @@ test('fail if beforeEach hook fails', function (t) {
 		a.pass();
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.failCount, 1);
+	runner.run({}).then(function (stats) {
+		t.is(stats.failCount, 1);
 		t.same(arr, ['a']);
 		t.end();
 	});
@@ -282,8 +282,8 @@ test('shared context', function (t) {
 		a.deepEqual(a.context.arr, ['a', 'b', 'c']);
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.failCount, 0);
+	runner.run({}).then(function (stats) {
+		t.is(stats.failCount, 0);
 		t.end();
 	});
 });
@@ -301,8 +301,8 @@ test('shared context of any type', function (t) {
 		a.is(a.context, 'foo');
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.failCount, 0);
+	runner.run({}).then(function (stats) {
+		t.is(stats.failCount, 0);
 		t.end();
 	});
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -194,10 +194,10 @@ test('skip test', function (t) {
 		runner.skip('should be a todo');
 	}, {message: 'Expected a function. Use `test.todo()` for tests without a function.'});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.testCount, 2);
-		t.is(runner.stats.passCount, 1);
-		t.is(runner.stats.skipCount, 1);
+	runner.run({}).then(function (stats) {
+		t.is(stats.testCount, 2);
+		t.is(stats.passCount, 1);
+		t.is(stats.skipCount, 1);
 		t.same(arr, ['a']);
 		t.end();
 	});
@@ -233,10 +233,10 @@ test('todo test', function (t) {
 		runner.todo();
 	}, {message: '`todo` tests require a title'});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.testCount, 2);
-		t.is(runner.stats.passCount, 1);
-		t.is(runner.stats.todoCount, 1);
+	runner.run({}).then(function (stats) {
+		t.is(stats.testCount, 2);
+		t.is(stats.passCount, 1);
+		t.is(stats.todoCount, 1);
 		t.same(arr, ['a']);
 		t.end();
 	});
@@ -256,16 +256,16 @@ test('only test', function (t) {
 		arr.push('b');
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.testCount, 1);
-		t.is(runner.stats.passCount, 1);
+	runner.run({}).then(function (stats) {
+		t.is(stats.testCount, 1);
+		t.is(stats.passCount, 1);
 		t.same(arr, ['b']);
 		t.end();
 	});
 });
 
 test('runOnlyExclusive option test', function (t) {
-	t.plan(4);
+	t.plan(1);
 
 	var runner = new Runner();
 	var options = {runOnlyExclusive: true};
@@ -275,11 +275,8 @@ test('runOnlyExclusive option test', function (t) {
 		arr.push('a');
 	});
 
-	runner.run(options).then(function () {
-		t.is(runner.stats.failCount, 0);
-		t.is(runner.stats.passCount, 0);
-		t.is(runner.stats.skipCount, 0);
-		t.is(runner.stats.testCount, 0);
+	runner.run(options).then(function (stats) {
+		t.is(stats, null);
 		t.end();
 	});
 });
@@ -416,10 +413,10 @@ test('options.match will not run tests with non-matching titles', function (t) {
 		t.fail();
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.skipCount, 0);
-		t.is(runner.stats.passCount, 2);
-		t.is(runner.stats.testCount, 2);
+	runner.run({}).then(function (stats) {
+		t.is(stats.skipCount, 0);
+		t.is(stats.passCount, 2);
+		t.is(stats.testCount, 2);
 		t.end();
 	});
 });
@@ -441,10 +438,10 @@ test('options.match hold no effect on hooks with titles', function (t) {
 		t.is(actual, 'foo');
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.skipCount, 0);
-		t.is(runner.stats.passCount, 1);
-		t.is(runner.stats.testCount, 1);
+	runner.run({}).then(function (stats) {
+		t.is(stats.skipCount, 0);
+		t.is(stats.passCount, 1);
+		t.is(stats.testCount, 1);
 		t.end();
 	});
 });
@@ -464,10 +461,10 @@ test('options.match overrides .only', function (t) {
 		t.pass();
 	});
 
-	runner.run({}).then(function () {
-		t.is(runner.stats.skipCount, 0);
-		t.is(runner.stats.passCount, 2);
-		t.is(runner.stats.testCount, 2);
+	runner.run({}).then(function (stats) {
+		t.is(stats.skipCount, 0);
+		t.is(stats.passCount, 2);
+		t.is(stats.testCount, 2);
 		t.end();
 	});
 });


### PR DESCRIPTION
Follow-up to #654. No longer collecting stats for every test that completes. Explicitly return `null` when no exclusive tests could be run.