### PR TITLE
Improve source pattern handling

### DIFF
--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -61,7 +61,9 @@ In AVA there's a distinction between *source files* and *test files*. As you can
 
 By default AVA watches for changes to the test files, `package.json`, and any other `.js` files. It'll ignore files in [certain directories](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) as provided by the [`ignore-by-default`] package.
 
-You can configure patterns for the source files using the [`--source` CLI flag] or in the `ava` section of your `package.json` file. Note that if you specify a negative pattern the directories from [`ignore-by-default`] will no longer be ignored, so you may want to repeat these in your config.
+You can configure patterns for the source files using the [`--source` CLI flag] or in the `ava` section of your `package.json` file.
+
+You can specify patterns to match files in the folders that would otherwise be ignored, e.g. use `node_modules/some-dependency/*.js` to specify all `.js` files in `node_modules/some-dependency` as a source, even though normally all files in `node_modules` are ignored. Note that you need to specify an exact directory; `{bower_components,node_modules}/**/*.js` won't work.
 
 If your tests write to disk they may trigger the watcher to rerun your tests. If this occurs you will need to use the `--source` flag.
 

--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -34,7 +34,7 @@ You could also set up a special script:
 {
   "scripts": {
     "test": "ava",
-    "test:watch": "ava --watch"
+    "watch:test": "ava --watch"
   }
 }
 ```
@@ -42,7 +42,17 @@ You could also set up a special script:
 And then use:
 
 ```console
-$ npm run test:watch
+$ npm run watch:test
+```
+
+Finally you could configure AVA to *always* run in watch mode by setting the `watch` key in the [`ava` section of your `package.json`]:
+
+```json
+{
+  "ava": {
+    "watch": true
+  }
+}
 ```
 
 Please note that the TAP reporter is unavailable when using watch mode.
@@ -61,7 +71,7 @@ In AVA there's a distinction between *source files* and *test files*. As you can
 
 By default AVA watches for changes to the test files, `package.json`, and any other `.js` files. It'll ignore files in [certain directories](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) as provided by the [`ignore-by-default`] package.
 
-You can configure patterns for the source files using the [`--source` CLI flag] or in the `ava` section of your `package.json` file.
+You can configure patterns for the source files in the [`ava` section of your `package.json`] file, using the `source` key. This is the recommended way, though you could also use the [`--source` CLI flag].
 
 You can specify patterns to match files in the folders that would otherwise be ignored, e.g. use `node_modules/some-dependency/*.js` to specify all `.js` files in `node_modules/some-dependency` as a source, even though normally all files in `node_modules` are ignored. Note that you need to specify an exact directory; `{bower_components,node_modules}/**/*.js` won't work.
 
@@ -83,17 +93,17 @@ You can quickly rerun all tests by typing <kbd>r</kbd> on the console, followed 
 
 ## Debugging
 
-Sometimes watch mode does something surprising like rerunning all tests when you thought only a single test would be run. To see its reasoning you can enable a debug mode:
+Sometimes watch mode does something surprising like rerunning all tests when you thought only a single test would be run. To see its reasoning you can enable a debug mode. This will work best with the verbose reporter:
 
 ```console
-$ DEBUG=ava:watcher npm test -- --watch
+$ DEBUG=ava:watcher npm test -- --watch --verbose
 ```
 
 On Windows use:
 
 ```console
 $ set DEBUG=ava:watcher
-$ npm test -- --watch
+$ npm test -- --watch --verbose
 ```
 
 ## Help us make watch mode better
@@ -105,3 +115,4 @@ Watch mode is relatively new and there might be some rough edges. Please [report
 [`--require` CLI flag]: https://github.com/sindresorhus/ava#cli
 [`--source` CLI flag]: https://github.com/sindresorhus/ava#cli
 [`.only` modifier]: https://github.com/sindresorhus/ava#running-specific-tests
+[`ava` section of your `package.json`]: https://github.com/sindresorhus/ava#configuration

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -27,6 +27,12 @@ function rethrowAsync(err) {
 	});
 }
 
+function getDefaultIgnorePatterns() {
+	return defaultIgnore.map(function (dir) {
+		return dir + '/**/*';
+	});
+}
+
 // Used on paths before they're passed to multimatch to Harmonize matching
 // across platforms.
 var matchable = process.platform === 'win32' ? slash : function (path) {
@@ -289,15 +295,22 @@ function getChokidarPatterns(files, sources) {
 		}
 	});
 
+	// Allow source patterns to override the default ignore patterns. Chokidar
+	// ignores paths that match the list of ignored patterns. It uses anymatch
+	// under the hood, which supports negation patterns. For any source pattern
+	// that starts with an ignored directory, ensure the corresponding negation
+	// pattern is added to the ignored paths.
+	var overrideDefaultIgnorePatterns = paths.filter(function (pattern) {
+		return defaultIgnore.indexOf(pattern.split('/')[0]) >= 0;
+	}).map(function (pattern) {
+		return '!' + pattern;
+	});
+	ignored = getDefaultIgnorePatterns().concat(ignored, overrideDefaultIgnorePatterns);
+
 	if (paths.length === 0) {
 		paths = ['package.json', '**/*.js'];
 	}
-
 	paths = paths.concat(files);
-
-	if (ignored.length === 0) {
-		ignored = defaultIgnore;
-	}
 
 	return {
 		paths: paths,
@@ -306,25 +319,27 @@ function getChokidarPatterns(files, sources) {
 }
 
 function makeSourceMatcher(sources) {
-	var patterns = sources;
+	var mixedPatterns = [];
+	var defaultIgnorePatterns = getDefaultIgnorePatterns();
+	var overrideDefaultIgnorePatterns = [];
 
-	var hasPositivePattern = patterns.some(function (pattern) {
-		return pattern[0] !== '!';
-	});
+	var hasPositivePattern = false;
+	sources.forEach(function (pattern) {
+		mixedPatterns.push(pattern);
+		if (!hasPositivePattern && pattern[0] !== '!') {
+			hasPositivePattern = true;
+		}
 
-	var hasNegativePattern = patterns.some(function (pattern) {
-		return pattern[0] === '!';
+		// Extract patterns that start with an ignored directory. These need to be
+		// rematched separately.
+		if (defaultIgnore.indexOf(pattern.split('/')[0]) >= 0) {
+			overrideDefaultIgnorePatterns.push(pattern);
+		}
 	});
 
 	// Same defaults as used for Chokidar.
 	if (!hasPositivePattern) {
-		patterns = ['package.json', '**/*.js'].concat(patterns);
-	}
-
-	if (!hasNegativePattern) {
-		patterns = patterns.concat(defaultIgnore.map(function (dir) {
-			return '!' + dir + '/**/*';
-		}));
+		mixedPatterns = ['package.json', '**/*.js'].concat(mixedPatterns);
 	}
 
 	return function (path) {
@@ -336,7 +351,22 @@ function makeSourceMatcher(sources) {
 			return false;
 		}
 
-		return multimatch(path, patterns).length === 1;
+		var isSource = multimatch(path, mixedPatterns).length === 1;
+		if (!isSource) {
+			return false;
+		}
+
+		var isIgnored = multimatch(path, defaultIgnorePatterns).length === 1;
+		if (!isIgnored) {
+			return true;
+		}
+
+		var isErroneouslyIgnored = multimatch(path, overrideDefaultIgnorePatterns).length === 1;
+		if (isErroneouslyIgnored) {
+			return true;
+		}
+
+		return false;
 	};
 }
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -328,13 +328,15 @@ function makeSourceMatcher(sources) {
 	}
 
 	return function (path) {
+		path = matchable(path);
+
 		// Ignore paths outside the current working directory. They can't be matched
 		// to a pattern.
-		if (/^\.\./.test(path)) {
+		if (/^\.\.\//.test(path)) {
 			return false;
 		}
 
-		return multimatch(matchable(path), patterns).length === 1;
+		return multimatch(path, patterns).length === 1;
 	};
 }
 


### PR DESCRIPTION
Bugfix where `..file.js` sources were treated as being outside the current working directory. But the main change of this PR is that negated source patterns are now handled much better :boom: 

Fixes #614. Allow negated source patterns to be specified without unsetting the default negation patterns.

Allow source patterns to override the default negation patterns if they start with one of the ignored directories.