### PR TITLE
add missing link to .only modifier in watch mode recipe

### DIFF
--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -71,7 +71,7 @@ Dependency tracking works for required modules. Custom extensions and transpiler
 
 ## Watch mode and the `.only` modifier
 
-The `.only` modifier disables watch mode's dependency tracking algorithm. When a change is made, all `.only` tests will be rerun, regardless of whether the test depends on the changed file.
+The [`.only` modifier] disables watch mode's dependency tracking algorithm. When a change is made, all `.only` tests will be rerun, regardless of whether the test depends on the changed file.
 
 ## Manually rerunning all tests
 


### PR DESCRIPTION
Thanks @forresst for [pointing out](https://github.com/sindresorhus/ava/commit/e57908a91aad0e875c8a2ca9157edc7c4e0840b5#commitcomment-17001621) I dropped the link during editing.