### PR TITLE
Improve watch logging

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -50,6 +50,14 @@ Logger.prototype.finish = function (runStatus) {
 	this.write(this.reporter.finish(runStatus), runStatus);
 };
 
+Logger.prototype.clear = function () {
+	if (!this.reporter.clear) {
+		return;
+	}
+
+	this.write(this.reporter.clear());
+};
+
 Logger.prototype.write = function (str, runStatus) {
 	if (typeof str === 'undefined') {
 		return;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -50,12 +50,21 @@ Logger.prototype.finish = function (runStatus) {
 	this.write(this.reporter.finish(runStatus), runStatus);
 };
 
-Logger.prototype.clear = function () {
-	if (!this.reporter.clear) {
+Logger.prototype.section = function () {
+	if (!this.reporter.section) {
 		return;
 	}
 
+	this.write(this.reporter.section());
+};
+
+Logger.prototype.clear = function () {
+	if (!this.reporter.clear) {
+		return false;
+	}
+
 	this.write(this.reporter.clear());
+	return true;
 };
 
 Logger.prototype.write = function (str, runStatus) {

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -113,32 +113,26 @@ MiniReporter.prototype.unhandledError = function (err) {
 	}
 };
 
-MiniReporter.prototype.reportCounts = function () {
-	var status = '';
+MiniReporter.prototype.reportCounts = function (time) {
+	var lines = [
+		this.passCount > 0 ? '\n   ' + colors.pass(this.passCount, 'passed') : '',
+		this.failCount > 0 ? '\n   ' + colors.error(this.failCount, 'failed') : '',
+		this.skipCount > 0 ? '\n   ' + colors.skip(this.skipCount, 'skipped') : '',
+		this.todoCount > 0 ? '\n   ' + colors.todo(this.todoCount, 'todo') : ''
+	].filter(Boolean);
 
-	if (this.passCount > 0) {
-		status += '\n   ' + colors.pass(this.passCount, 'passed');
+	if (time && lines.length > 0) {
+		lines[0] += ' ' + time;
 	}
 
-	if (this.failCount > 0) {
-		status += '\n   ' + colors.error(this.failCount, 'failed');
-	}
-
-	if (this.skipCount > 0) {
-		status += '\n   ' + colors.skip(this.skipCount, 'skipped');
-	}
-
-	if (this.todoCount > 0) {
-		status += '\n   ' + colors.todo(this.todoCount, 'todo');
-	}
-
-	return status;
+	return lines.join('');
 };
 
 MiniReporter.prototype.finish = function (runStatus) {
 	this.clearInterval();
 
-	var status = this.reportCounts();
+	var time = chalk.gray.dim('[' + new Date().toLocaleTimeString('en-US', {hour12: false}) + ']');
+	var status = this.reportCounts(time);
 
 	if (this.rejectionCount > 0) {
 		status += '\n   ' + colors.error(this.rejectionCount, plur('rejection', this.rejectionCount));

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -193,6 +193,10 @@ MiniReporter.prototype.finish = function (runStatus) {
 	return status;
 };
 
+MiniReporter.prototype.clear = function () {
+	return '';
+};
+
 MiniReporter.prototype.write = function (str) {
 	cliCursor.hide();
 	this.currentStatus = str;

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -156,12 +156,12 @@ MiniReporter.prototype.finish = function (runStatus) {
 			var description;
 
 			if (test.error) {
-				description = '  ' + test.error.message + '\n  ' + stripFirstLine(test.error.stack);
+				description = '   ' + test.error.message + '\n  ' + stripFirstLine(test.error.stack).trimRight();
 			} else {
 				description = JSON.stringify(test);
 			}
 
-			status += '\n\n  ' + colors.error(i + '.', title) + '\n';
+			status += '\n\n\n   ' + colors.error(i + '.', title) + '\n';
 			status += colors.stack(description);
 		});
 	}
@@ -175,22 +175,18 @@ MiniReporter.prototype.finish = function (runStatus) {
 			i++;
 
 			if (err.type === 'exception' && err.name === 'AvaError') {
-				status += '\n\n  ' + colors.error(cross + ' ' + err.message) + '\n';
+				status += '\n\n\n   ' + colors.error(cross + ' ' + err.message);
 			} else {
 				var title = err.type === 'rejection' ? 'Unhandled Rejection' : 'Uncaught Exception';
-				var description = err.stack ? err.stack : JSON.stringify(err);
+				var description = err.stack ? err.stack.trimRight() : JSON.stringify(err);
 
-				status += '\n\n  ' + colors.error(i + '.', title) + '\n';
-				status += '  ' + colors.stack(description);
+				status += '\n\n\n   ' + colors.error(i + '.', title) + '\n';
+				status += '   ' + colors.stack(description);
 			}
 		});
 	}
 
-	if (this.failCount === 0 && this.rejectionCount === 0 && this.exceptionCount === 0) {
-		status += '\n';
-	}
-
-	return status;
+	return status + '\n';
 };
 
 MiniReporter.prototype.clear = function () {

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -7,6 +7,7 @@ var spinners = require('cli-spinners');
 var chalk = require('chalk');
 var cliTruncate = require('cli-truncate');
 var cross = require('figures').cross;
+var repeating = require('repeating');
 var colors = require('../colors');
 
 chalk.enabled = true;
@@ -187,6 +188,10 @@ MiniReporter.prototype.finish = function (runStatus) {
 	}
 
 	return status + '\n';
+};
+
+MiniReporter.prototype.section = function () {
+	return '\n' + chalk.gray.dim(repeating('\u2500', process.stdout.columns || 80));
 };
 
 MiniReporter.prototype.clear = function () {

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -1,6 +1,7 @@
 'use strict';
 var prettyMs = require('pretty-ms');
 var figures = require('figures');
+var chalk = require('chalk');
 var plur = require('plur');
 var colors = require('../colors');
 
@@ -68,26 +69,19 @@ VerboseReporter.prototype.unhandledError = function (err) {
 VerboseReporter.prototype.finish = function (runStatus) {
 	var output = '\n';
 
-	if (runStatus.failCount > 0) {
-		output += '  ' + colors.error(runStatus.failCount, plur('test', runStatus.failCount), 'failed') + '\n';
-	} else {
-		output += '  ' + colors.pass(runStatus.passCount, plur('test', runStatus.passCount), 'passed') + '\n';
-	}
+	var lines = [
+		runStatus.failCount > 0 ?
+			'  ' + colors.error(runStatus.failCount, plur('test', runStatus.failCount), 'failed') :
+			'  ' + colors.pass(runStatus.passCount, plur('test', runStatus.passCount), 'passed'),
+		runStatus.skipCount > 0 ? '  ' + colors.skip(runStatus.skipCount, plur('test', runStatus.skipCount), 'skipped') : '',
+		runStatus.todoCount > 0 ? '  ' + colors.todo(runStatus.todoCount, plur('test', runStatus.todoCount), 'todo') : '',
+		runStatus.rejectionCount > 0 ? '  ' + colors.error(runStatus.rejectionCount, 'unhandled', plur('rejection', runStatus.rejectionCount)) : '',
+		runStatus.exceptionCount > 0 ? '  ' + colors.error(runStatus.exceptionCount, 'uncaught', plur('exception', runStatus.exceptionCount)) : ''
+	].filter(Boolean);
 
-	if (runStatus.skipCount > 0) {
-		output += '  ' + colors.skip(runStatus.skipCount, plur('test', runStatus.skipCount), 'skipped') + '\n';
-	}
-
-	if (runStatus.todoCount > 0) {
-		output += '  ' + colors.todo(runStatus.todoCount, plur('test', runStatus.todoCount), 'todo') + '\n';
-	}
-
-	if (runStatus.rejectionCount > 0) {
-		output += '  ' + colors.error(runStatus.rejectionCount, 'unhandled', plur('rejection', runStatus.rejectionCount)) + '\n';
-	}
-
-	if (runStatus.exceptionCount > 0) {
-		output += '  ' + colors.error(runStatus.exceptionCount, 'uncaught', plur('exception', runStatus.exceptionCount)) + '\n';
+	if (lines.length > 0) {
+		lines[0] += ' ' + chalk.gray.dim('[' + new Date().toLocaleTimeString('en-US', {hour12: false}) + ']');
+		output += lines.join('\n') + '\n';
 	}
 
 	if (runStatus.failCount > 0) {

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -81,12 +81,10 @@ VerboseReporter.prototype.finish = function (runStatus) {
 
 	if (lines.length > 0) {
 		lines[0] += ' ' + chalk.gray.dim('[' + new Date().toLocaleTimeString('en-US', {hour12: false}) + ']');
-		output += lines.join('\n') + '\n';
+		output += lines.join('\n');
 	}
 
 	if (runStatus.failCount > 0) {
-		output += '\n';
-
 		var i = 0;
 
 		runStatus.tests.forEach(function (test) {
@@ -96,12 +94,13 @@ VerboseReporter.prototype.finish = function (runStatus) {
 
 			i++;
 
-			output += '  ' + colors.error(i + '.', test.title) + '\n';
-			output += '  ' + colors.stack(test.error.stack) + '\n';
+			output += '\n\n\n  ' + colors.error(i + '.', test.title) + '\n';
+			var stack = test.error.stack ? test.error.stack.trimRight() : '';
+			output += '  ' + colors.stack(stack);
 		});
 	}
 
-	return output;
+	return output + '\n';
 };
 
 VerboseReporter.prototype.write = function (str) {

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -3,6 +3,7 @@ var prettyMs = require('pretty-ms');
 var figures = require('figures');
 var chalk = require('chalk');
 var plur = require('plur');
+var repeating = require('repeating');
 var colors = require('../colors');
 
 Object.keys(colors).forEach(function (key) {
@@ -101,6 +102,10 @@ VerboseReporter.prototype.finish = function (runStatus) {
 	}
 
 	return output + '\n';
+};
+
+VerboseReporter.prototype.section = function () {
+	return chalk.gray.dim(repeating('\u2500', process.stdout.columns || 80));
 };
 
 VerboseReporter.prototype.write = function (str) {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -39,10 +39,16 @@ function Watcher(logger, api, files, sources) {
 	this.isTest = makeTestMatcher(files, AvaFiles.defaultExcludePatterns());
 
 	var isFirstRun = true;
+	this.clearLogOnNextRun = true;
 	this.run = function (specificFiles) {
 		if (isFirstRun) {
 			isFirstRun = false;
 		} else {
+			if (this.clearLogOnNextRun) {
+				logger.clear();
+			}
+			this.clearLogOnNextRun = true;
+
 			logger.reset();
 			logger.start();
 		}
@@ -64,10 +70,12 @@ function Watcher(logger, api, files, sources) {
 			}
 		}
 
+		var self = this;
 		this.busy = api.run(specificFiles || files, {
 			runOnlyExclusive: runOnlyExclusive
 		}).then(function (runStatus) {
 			logger.finish(runStatus);
+			self.clearLogOnNextRun = self.clearLogOnNextRun && runStatus.failCount === 0;
 		}, rethrowAsync);
 	};
 
@@ -183,6 +191,7 @@ Watcher.prototype.observeStdin = function (stdin) {
 			// Cancel the debouncer again, it might have restarted while waiting for
 			// the busy promise to fulfil.
 			self.debouncer.cancel();
+			self.clearLogOnNextRun = false;
 			self.rerunAll();
 		});
 	});

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -37,8 +37,15 @@ function Watcher(logger, api, files, sources) {
 	this.debouncer = new Debouncer(this);
 
 	this.isTest = makeTestMatcher(files, AvaFiles.defaultExcludePatterns());
+
+	var isFirstRun = true;
 	this.run = function (specificFiles) {
-		logger.reset();
+		if (isFirstRun) {
+			isFirstRun = false;
+		} else {
+			logger.reset();
+			logger.start();
+		}
 
 		var runOnlyExclusive = false;
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -44,8 +44,10 @@ function Watcher(logger, api, files, sources) {
 		if (isFirstRun) {
 			isFirstRun = false;
 		} else {
-			if (this.clearLogOnNextRun) {
-				logger.clear();
+			var cleared = this.clearLogOnNextRun && logger.clear();
+			if (!cleared) {
+				logger.reset();
+				logger.section();
 			}
 			this.clearLogOnNextRun = true;
 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "power-assert-formatter": "^1.3.0",
     "power-assert-renderers": "^0.1.0",
     "pretty-ms": "^2.0.0",
+    "repeating": "^2.0.0",
     "require-precompiled": "^0.1.0",
     "resolve-cwd": "^1.0.0",
     "set-immediate-shim": "^1.0.1",

--- a/test/cli.js
+++ b/test/cli.js
@@ -235,7 +235,7 @@ if (hasChokidar) {
 			t.is(err.code, 1);
 			t.match(stderr, 'The TAP reporter is not available when using watch mode.');
 			t.end();
-		}).stderr.pipe(process.stderr);
+		});
 	});
 
 	['--watch', '-w'].forEach(function (watchFlag) {
@@ -245,7 +245,7 @@ if (hasChokidar) {
 					t.is(err.code, 1);
 					t.match(stderr, 'The TAP reporter is not available when using watch mode.');
 					t.end();
-				}).stderr.pipe(process.stderr);
+				});
 			});
 		});
 	});

--- a/test/helper/compare-line-output.js
+++ b/test/helper/compare-line-output.js
@@ -1,0 +1,27 @@
+'use strict';
+var SKIP_UNTIL_EMPTY_LINE = {};
+
+function compareLineOutput(t, actual, lineExpectations) {
+	var actualLines = actual.split('\n');
+
+	var expectationIndex = 0;
+	var lineIndex = 0;
+	while (lineIndex < actualLines.length && expectationIndex < lineExpectations.length) {
+		var line = actualLines[lineIndex++];
+		var expected = lineExpectations[expectationIndex++];
+		if (expected === SKIP_UNTIL_EMPTY_LINE) {
+			lineIndex = actualLines.indexOf('', lineIndex);
+			continue;
+		}
+
+		if (typeof expected === 'string') {
+			// Assertion titles use 1-based line indexes
+			t.is(line, expected, 'line ' + lineIndex + ' ≪' + line + '≫ is ≪' + expected + '≫');
+		} else {
+			t.match(line, expected, 'line ' + lineIndex + ' ≪' + line + '≫ matches ' + expected);
+		}
+	}
+}
+
+module.exports = compareLineOutput;
+compareLineOutput.SKIP_UNTIL_EMPTY_LINE = SKIP_UNTIL_EMPTY_LINE;

--- a/test/logger.js
+++ b/test/logger.js
@@ -45,6 +45,23 @@ test('only write if reset is supported by reporter', function (t) {
 	t.end();
 });
 
+test('only call clear if supported by reporter', function (t) {
+	var tapReporter = tap();
+	var logger = new Logger(tapReporter);
+	tapReporter.clear = undefined;
+	logger.clear();
+	t.end();
+});
+
+test('only write if clear is supported by reporter', function (t) {
+	var tapReporter = tap();
+	var logger = new Logger(tapReporter);
+	tapReporter.clear = undefined;
+	logger.write = t.fail;
+	logger.clear();
+	t.end();
+});
+
 test('writes the reporter reset result', function (t) {
 	var tapReporter = tap();
 	var logger = new Logger(tapReporter);

--- a/test/logger.js
+++ b/test/logger.js
@@ -45,6 +45,23 @@ test('only write if reset is supported by reporter', function (t) {
 	t.end();
 });
 
+test('only call section if supported by reporter', function (t) {
+	var tapReporter = tap();
+	var logger = new Logger(tapReporter);
+	tapReporter.section = undefined;
+	logger.section();
+	t.end();
+});
+
+test('only write if section is supported by reporter', function (t) {
+	var tapReporter = tap();
+	var logger = new Logger(tapReporter);
+	tapReporter.section = undefined;
+	logger.write = t.fail;
+	logger.section();
+	t.end();
+});
+
 test('only call clear if supported by reporter', function (t) {
 	var tapReporter = tap();
 	var logger = new Logger(tapReporter);
@@ -59,6 +76,22 @@ test('only write if clear is supported by reporter', function (t) {
 	tapReporter.clear = undefined;
 	logger.write = t.fail;
 	logger.clear();
+	t.end();
+});
+
+test('return false if clear is not supported by reporter', function (t) {
+	var tapReporter = tap();
+	var logger = new Logger(tapReporter);
+	tapReporter.clear = undefined;
+	t.false(logger.clear());
+	t.end();
+});
+
+test('return true if clear is supported by reporter', function (t) {
+	var tapReporter = tap();
+	var logger = new Logger(tapReporter);
+	tapReporter.clear = function () {};
+	t.true(logger.clear());
 	t.end();
 });
 

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -2,6 +2,7 @@
 var chalk = require('chalk');
 var test = require('tap').test;
 var cross = require('figures').cross;
+var lolex = require('lolex');
 var AvaError = require('../../lib/ava-error');
 var _miniReporter = require('../../lib/reporters/mini');
 var beautifyStack = require('../../lib/beautify-stack');
@@ -23,6 +24,9 @@ function miniReporter() {
 }
 
 process.stderr.setMaxListeners(50);
+
+lolex.install(new Date('2014-11-19T00:19:12+0700').getTime(), ['Date']);
+var time = ' ' + chalk.grey.dim('[17:19:12]');
 
 test('start', function (t) {
 	var reporter = _miniReporter();
@@ -151,7 +155,7 @@ test('results with passing tests', function (t) {
 
 	var actualOutput = reporter.finish();
 	var expectedOutput = [
-		'\n   ' + chalk.green('1 passed'),
+		'\n   ' + chalk.green('1 passed') + time,
 		''
 	].join('\n');
 
@@ -167,7 +171,7 @@ test('results with skipped tests', function (t) {
 
 	var actualOutput = reporter.finish();
 	var expectedOutput = [
-		'\n   ' + chalk.yellow('1 skipped'),
+		'\n   ' + chalk.yellow('1 skipped') + time,
 		''
 	].join('\n');
 
@@ -183,7 +187,7 @@ test('results with todo tests', function (t) {
 
 	var actualOutput = reporter.finish();
 	var expectedOutput = [
-		'\n   ' + chalk.blue('1 todo'),
+		'\n   ' + chalk.blue('1 todo') + time,
 		''
 	].join('\n');
 
@@ -199,7 +203,7 @@ test('results with passing skipped tests', function (t) {
 	var output = reporter.finish().split('\n');
 
 	t.is(output[0], '');
-	t.is(output[1], '   ' + chalk.green('1 passed'));
+	t.is(output[1], '   ' + chalk.green('1 passed') + time);
 	t.is(output[2], '   ' + chalk.yellow('1 skipped'));
 	t.is(output[3], '');
 	t.end();
@@ -221,7 +225,7 @@ test('results with passing tests and rejections', function (t) {
 	var output = reporter.finish(runStatus).split('\n');
 
 	t.is(output[0], '');
-	t.is(output[1], '   ' + chalk.green('1 passed'));
+	t.is(output[1], '   ' + chalk.green('1 passed') + time);
 	t.is(output[2], '   ' + chalk.red('1 rejection'));
 	t.is(output[3], '');
 	t.is(output[4], '  ' + chalk.red('1. Unhandled Rejection'));
@@ -249,7 +253,7 @@ test('results with passing tests and exceptions', function (t) {
 	var output = reporter.finish(runStatus).split('\n');
 
 	t.is(output[0], '');
-	t.is(output[1], '   ' + chalk.green('1 passed'));
+	t.is(output[1], '   ' + chalk.green('1 passed') + time);
 	t.is(output[2], '   ' + chalk.red('2 exceptions'));
 	t.is(output[3], '');
 	t.is(output[4], '  ' + chalk.red('1. Uncaught Exception'));
@@ -277,7 +281,7 @@ test('results with errors', function (t) {
 	var output = reporter.finish(runStatus).split('\n');
 
 	t.is(output[0], '');
-	t.is(output[1], '   ' + chalk.red('1 failed'));
+	t.is(output[1], '   ' + chalk.red('1 failed') + time);
 	t.is(output[2], '');
 	t.is(output[3], '  ' + chalk.red('1. failed'));
 	t.match(output[4], /failure/);

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -3,6 +3,7 @@ var chalk = require('chalk');
 var test = require('tap').test;
 var cross = require('figures').cross;
 var lolex = require('lolex');
+var repeating = require('repeating');
 var AvaError = require('../../lib/ava-error');
 var _miniReporter = require('../../lib/reporters/mini');
 var beautifyStack = require('../../lib/beautify-stack');
@@ -16,6 +17,7 @@ var graySpinner = chalk.gray.dim('⠋');
 // Needed because tap doesn't emulate a tty environment and thus this is
 // undefined, making `cli-truncate` append '...' to test titles
 process.stdout.columns = 5000;
+var fullWidthLine = chalk.gray.dim(repeating('\u2500', 5000));
 
 function miniReporter() {
 	var reporter = _miniReporter();
@@ -326,5 +328,13 @@ test('empty results after reset', function (t) {
 
 	var output = reporter.finish();
 	t.is(output, '\n');
+	t.end();
+});
+
+test('full-width line when sectioning', function (t) {
+	var reporter = miniReporter();
+
+	var output = reporter.section();
+	t.is(output, '\n' + fullWidthLine);
 	t.end();
 });

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -2,10 +2,14 @@
 var figures = require('figures');
 var chalk = require('chalk');
 var test = require('tap').test;
+var lolex = require('lolex');
 var beautifyStack = require('../../lib/beautify-stack');
 var verboseReporter = require('../../lib/reporters/verbose');
 
 chalk.enabled = true;
+
+lolex.install(new Date('2014-11-19T00:19:12+0700').getTime(), ['Date']);
+var time = ' ' + chalk.grey.dim('[17:19:12]');
 
 function createReporter() {
 	var reporter = verboseReporter();
@@ -195,7 +199,7 @@ test('results with passing tests', function (t) {
 	var actualOutput = reporter.finish(runStatus);
 	var expectedOutput = [
 		'',
-		'  ' + chalk.green('1 test passed'),
+		'  ' + chalk.green('1 test passed') + time,
 		''
 	].join('\n');
 
@@ -212,7 +216,7 @@ test('results with skipped tests', function (t) {
 	var actualOutput = reporter.finish(runStatus);
 	var expectedOutput = [
 		'',
-		'  ' + chalk.green('1 test passed'),
+		'  ' + chalk.green('1 test passed') + time,
 		'  ' + chalk.yellow('1 test skipped'),
 		''
 	].join('\n');
@@ -230,7 +234,7 @@ test('results with todo tests', function (t) {
 	var actualOutput = reporter.finish(runStatus);
 	var expectedOutput = [
 		'',
-		'  ' + chalk.green('1 test passed'),
+		'  ' + chalk.green('1 test passed') + time,
 		'  ' + chalk.blue('1 test todo'),
 		''
 	].join('\n');
@@ -248,7 +252,7 @@ test('results with passing tests and rejections', function (t) {
 	var actualOutput = reporter.finish(runStatus);
 	var expectedOutput = [
 		'',
-		'  ' + chalk.green('1 test passed'),
+		'  ' + chalk.green('1 test passed') + time,
 		'  ' + chalk.red('1 unhandled rejection'),
 		''
 	].join('\n');
@@ -266,7 +270,7 @@ test('results with passing tests and exceptions', function (t) {
 	var actualOutput = reporter.finish(runStatus);
 	var expectedOutput = [
 		'',
-		'  ' + chalk.green('1 test passed'),
+		'  ' + chalk.green('1 test passed') + time,
 		'  ' + chalk.red('1 uncaught exception'),
 		''
 	].join('\n');
@@ -285,7 +289,7 @@ test('results with passing tests, rejections and exceptions', function (t) {
 	var actualOutput = reporter.finish(runStatus);
 	var expectedOutput = [
 		'',
-		'  ' + chalk.green('1 test passed'),
+		'  ' + chalk.green('1 test passed') + time,
 		'  ' + chalk.red('1 unhandled rejection'),
 		'  ' + chalk.red('1 uncaught exception'),
 		''
@@ -309,7 +313,7 @@ test('results with errors', function (t) {
 
 	var output = reporter.finish(runStatus).split('\n');
 
-	t.is(output[1], '  ' + chalk.red('1 test failed'));
+	t.is(output[1], '  ' + chalk.red('1 test failed') + time);
 	t.is(output[3], '  ' + chalk.red('1. fail'));
 	t.match(output[4], /Error: error message/);
 	t.match(output[5], /test\/reporters\/verbose\.js/);

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -3,12 +3,17 @@ var figures = require('figures');
 var chalk = require('chalk');
 var test = require('tap').test;
 var lolex = require('lolex');
+var repeating = require('repeating');
 var beautifyStack = require('../../lib/beautify-stack');
 var colors = require('../../lib/colors');
 var verboseReporter = require('../../lib/reporters/verbose');
 var compareLineOutput = require('../helper/compare-line-output');
 
 chalk.enabled = true;
+
+// tap doesn't emulate a tty environment and thus process.stdout.columns is
+// undefined. Expect an 80 character wide line to be rendered.
+var fullWidthLine = chalk.gray.dim(repeating('\u2500', 80));
 
 lolex.install(new Date('2014-11-19T00:19:12+0700').getTime(), ['Date']);
 var time = ' ' + chalk.grey.dim('[17:19:12]');
@@ -333,6 +338,14 @@ test('results with errors', function (t) {
 		'  ' + chalk.red('2. fail two'),
 		'  ' + colors.stack('stack line with trailing whitespace')
 	]);
+	t.end();
+});
+
+test('full-width line when sectioning', function (t) {
+	var reporter = createReporter();
+
+	var output = reporter.section();
+	t.is(output, fullWidthLine);
 	t.end();
 });
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -561,18 +561,20 @@ group('chokidar is installed', function (beforeEach, test, group) {
 
 	["r", "rs"].forEach(function (input) {
 		test('reruns initial tests when "' + input + '" is entered on stdin', function (t) {
-			t.plan(2);
+			t.plan(4);
 			api.run.returns(Promise.resolve({}));
 			start().observeStdin(stdin);
 
 			stdin.write(input + '\n');
 			return delay().then(function () {
 				t.ok(api.run.calledTwice);
+				t.same(api.run.secondCall.args, [files, {runOnlyExclusive: false}]);
 
 				stdin.write('\t' + input + '  \n');
 				return delay();
 			}).then(function () {
 				t.ok(api.run.calledThrice);
+				t.same(api.run.thirdCall.args, [files, {runOnlyExclusive: false}]);
 			});
 		});
 


### PR DESCRIPTION
Fixes #670.

* When the mini and verbose reporters finish, add a timestamp after the first passed/failed/etc status line
* Ensure the watcher doesn't break the mini reporter's spinner on the first run
* Ensure the watcher restarts the mini reporter's spinner on subsequent runs
* Clear the mini reporter on subsequent runs, unless failures occurred or `r\n` was entered on stdin (because that inserts a line which can't be cleared)

Also includes some test improvements.