### PR TITLE
Ensure watcher receives dependencies again

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -125,9 +125,11 @@ Watcher.prototype.trackTestDependencies = function (api, sources) {
 		return nodePath.relative(cwd, absPath);
 	};
 
-	api.on('dependencies', function (file, dependencies) {
-		var sourceDeps = dependencies.map(relative).filter(isSource);
-		self.updateTestDependencies(file, sourceDeps);
+	api.on('test-run', function (runStatus) {
+		runStatus.on('dependencies', function (file, dependencies) {
+			var sourceDeps = dependencies.map(relative).filter(isSource);
+			self.updateTestDependencies(file, sourceDeps);
+		});
 	});
 };
 

--- a/test/fixture/watcher/with-dependencies/source.js
+++ b/test/fixture/watcher/with-dependencies/source.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = true;

--- a/test/fixture/watcher/with-dependencies/test-1.js
+++ b/test/fixture/watcher/with-dependencies/test-1.js
@@ -1,0 +1,6 @@
+import test from '../../../../';
+import dependency from './source.js';
+
+test('works', t => {
+	t.truthy(dependency);
+});

--- a/test/fixture/watcher/with-dependencies/test-2.js
+++ b/test/fixture/watcher/with-dependencies/test-2.js
@@ -1,0 +1,5 @@
+import test from '../../../../';
+
+test('works', t => {
+	t.pass();
+});


### PR DESCRIPTION
Since #713 the API no longer emits 'dependencies' events. These are emitted instead by the RunStatus, which can be obtained by listening to the 'test-run' event on the API.

The watcher tests use a mocked API object which wasn't updated to reflect these changes. Consequently dependency tracking was broken since #713 was merged.

This commit fixes the watcher and the corresponding tests. I've also added an integration test which does not rely on mocking, helping us detect breakage sooner.