### PR TITLE
watcher: improve clearance avoidance

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -83,7 +83,9 @@ function Watcher(logger, api, files, sources) {
 			runOnlyExclusive: runOnlyExclusive
 		}).then(function (runStatus) {
 			logger.finish(runStatus);
-			self.clearLogOnNextRun = self.clearLogOnNextRun && runStatus.failCount === 0;
+
+			var badCounts = runStatus.failCount + runStatus.rejectionCount + runStatus.exceptionCount;
+			self.clearLogOnNextRun = self.clearLogOnNextRun && badCounts === 0;
 		}, rethrowAsync);
 	};
 


### PR DESCRIPTION
Don't clear the reporter if the previous run had exceptions or rejections.

Improve the stubbing of the run status in the tests.