### PR TITLE
	watcher: remember failures from previous tests

### DIFF
--- a/api.js
+++ b/api.js
@@ -64,7 +64,7 @@ Api.prototype._onTimeout = function (runStatus) {
 
 	runStatus.handleExceptions({
 		exception: new AvaError(message),
-		file: null
+		file: undefined
 	});
 
 	runStatus.emit('timeout');
@@ -151,7 +151,7 @@ Api.prototype._run = function (files, _options) {
 					// continue to run.
 					runStatus.handleExceptions({
 						exception: err,
-						file: file
+						file: path.relative('.', file)
 					});
 
 					return {
@@ -197,7 +197,7 @@ Api.prototype._run = function (files, _options) {
 
 				runStatus.handleExceptions({
 					exception: err,
-					file: file
+					file: path.relative('.', file)
 				});
 
 				resolve([]);

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -143,6 +143,10 @@ MiniReporter.prototype.finish = function (runStatus) {
 		status += '\n   ' + colors.error(this.exceptionCount, plur('exception', this.exceptionCount));
 	}
 
+	if (runStatus.previousFailCount > 0) {
+		status += '\n   ' + colors.error(runStatus.previousFailCount, 'previous', plur('failure', runStatus.previousFailCount), 'in test files that were not rerun');
+	}
+
 	var i = 0;
 
 	if (this.failCount > 0) {

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -77,7 +77,8 @@ VerboseReporter.prototype.finish = function (runStatus) {
 		runStatus.skipCount > 0 ? '  ' + colors.skip(runStatus.skipCount, plur('test', runStatus.skipCount), 'skipped') : '',
 		runStatus.todoCount > 0 ? '  ' + colors.todo(runStatus.todoCount, plur('test', runStatus.todoCount), 'todo') : '',
 		runStatus.rejectionCount > 0 ? '  ' + colors.error(runStatus.rejectionCount, 'unhandled', plur('rejection', runStatus.rejectionCount)) : '',
-		runStatus.exceptionCount > 0 ? '  ' + colors.error(runStatus.exceptionCount, 'uncaught', plur('exception', runStatus.exceptionCount)) : ''
+		runStatus.exceptionCount > 0 ? '  ' + colors.error(runStatus.exceptionCount, 'uncaught', plur('exception', runStatus.exceptionCount)) : '',
+		runStatus.previousFailCount > 0 ? '  ' + colors.error(runStatus.previousFailCount, 'previous', plur('failure', runStatus.previousFailCount), 'in test files that were not rerun') : ''
 	].filter(Boolean);
 
 	if (lines.length > 0) {

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -27,6 +27,7 @@ function RunStatus(opts) {
 	this.failCount = 0;
 	this.fileCount = 0;
 	this.testCount = 0;
+	this.previousFailCount = 0;
 	this.errors = [];
 	this.stats = [];
 	this.tests = [];

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -44,12 +44,10 @@ function Watcher(logger, api, files, sources) {
 
 	this.isTest = makeTestMatcher(files, AvaFiles.defaultExcludePatterns());
 
-	var isFirstRun = true;
 	this.clearLogOnNextRun = true;
+	this.runVector = 0;
 	this.run = function (specificFiles) {
-		if (isFirstRun) {
-			isFirstRun = false;
-		} else {
+		if (this.runVector > 0) {
 			var cleared = this.clearLogOnNextRun && logger.clear();
 			if (!cleared) {
 				logger.reset();
@@ -60,6 +58,8 @@ function Watcher(logger, api, files, sources) {
 			logger.reset();
 			logger.start();
 		}
+
+		var currentVector = this.runVector += 1;
 
 		var runOnlyExclusive = false;
 
@@ -82,6 +82,7 @@ function Watcher(logger, api, files, sources) {
 		this.busy = api.run(specificFiles || files, {
 			runOnlyExclusive: runOnlyExclusive
 		}).then(function (runStatus) {
+			runStatus.previousFailCount = self.sumPreviousFailures(currentVector);
 			logger.finish(runStatus);
 
 			var badCounts = runStatus.failCount + runStatus.rejectionCount + runStatus.exceptionCount;
@@ -94,6 +95,9 @@ function Watcher(logger, api, files, sources) {
 
 	this.filesWithExclusiveTests = [];
 	this.trackExclusivity(api);
+
+	this.filesWithFailures = [];
+	this.trackFailures(api);
 
 	this.dirtyStates = {};
 	this.watchFiles(files, sources);
@@ -121,10 +125,8 @@ Watcher.prototype.watchFiles = function (files, sources) {
 Watcher.prototype.trackTestDependencies = function (api, sources) {
 	var self = this;
 	var isSource = makeSourceMatcher(sources);
-	var cwd = process.cwd();
-
 	var relative = function (absPath) {
-		return nodePath.relative(cwd, absPath);
+		return nodePath.relative('.', absPath);
 	};
 
 	api.on('test-run', function (runStatus) {
@@ -177,10 +179,68 @@ Watcher.prototype.updateExclusivity = function (file, hasExclusiveTests) {
 	}
 };
 
+Watcher.prototype.trackFailures = function (api) {
+	var self = this;
+
+	api.on('test-run', function (runStatus, files) {
+		files.forEach(function (file) {
+			self.pruneFailures(nodePath.relative('.', file));
+		});
+
+		var currentVector = self.runVector;
+		runStatus.on('error', function (err) {
+			self.countFailure(err.file, currentVector);
+		});
+		runStatus.on('test', function (result) {
+			if (result.error) {
+				self.countFailure(result.file, currentVector);
+			}
+		});
+	});
+};
+
+Watcher.prototype.pruneFailures = function (file) {
+	this.filesWithFailures = this.filesWithFailures.filter(function (state) {
+		return state.file !== file;
+	});
+};
+
+Watcher.prototype.countFailure = function (file, vector) {
+	var isUpdate = this.filesWithFailures.some(function (state) {
+		if (state.file !== file) {
+			return false;
+		}
+
+		state.count++;
+		return true;
+	});
+
+	if (!isUpdate) {
+		this.filesWithFailures.push({
+			file: file,
+			vector: vector,
+			count: 1
+		});
+	}
+};
+
+Watcher.prototype.sumPreviousFailures = function (beforeVector) {
+	var total = 0;
+
+	this.filesWithFailures.forEach(function (state) {
+		if (state.vector < beforeVector) {
+			total += state.count;
+		}
+	});
+
+	return total;
+};
+
 Watcher.prototype.cleanUnlinkedTests = function (unlinkedTests) {
 	unlinkedTests.forEach(function (testFile) {
 		this.updateTestDependencies(testFile, []);
 		this.updateExclusivity(testFile, false);
+		this.pruneFailures(testFile);
 	}, this);
 };
 

--- a/test/api.js
+++ b/test/api.js
@@ -464,7 +464,7 @@ test('test file with no tests causes an AvaError to be emitted', function (t) {
 	return api.run([path.join(__dirname, 'fixture/no-tests.js')]);
 });
 
-test('test file that immediately exits with 0 exit code ', function (t) {
+test('test file that immediately exits with 0 exit code', function (t) {
 	t.plan(2);
 
 	var api = new Api();
@@ -477,6 +477,22 @@ test('test file that immediately exits with 0 exit code ', function (t) {
 	});
 
 	return api.run([path.join(__dirname, 'fixture/immediate-0-exit.js')]);
+});
+
+test('test file that immediately exits with 3 exit code', function (t) {
+	t.plan(3);
+
+	var api = new Api();
+
+	api.on('test-run', function (runStatus) {
+		runStatus.on('error', function (err) {
+			t.is(err.name, 'AvaError');
+			t.is(err.file, path.join('test', 'fixture', 'immediate-3-exit.js'));
+			t.match(err.message, /exited with a non-zero exit code: 3/);
+		});
+	});
+
+	return api.run([path.join(__dirname, 'fixture/immediate-3-exit.js')]);
 });
 
 test('testing nonexistent files causes an AvaError to be emitted', function (t) {
@@ -905,13 +921,14 @@ test('using --match with no matching tests causes an AvaError to be emitted', fu
 });
 
 test('errors thrown when running files are emitted', function (t) {
-	t.plan(2);
+	t.plan(3);
 
 	var api = new Api();
 
 	api.on('test-run', function (runStatus) {
 		runStatus.on('error', function (err) {
 			t.is(err.name, 'SyntaxError');
+			t.is(err.file, path.join('test', 'fixture', 'syntax-error.js'));
 			t.match(err.message, /Unexpected token/);
 		});
 	});

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -157,7 +157,7 @@ test('results with passing tests', function (t) {
 	reporter.passCount = 1;
 	reporter.failCount = 0;
 
-	var actualOutput = reporter.finish();
+	var actualOutput = reporter.finish({});
 	var expectedOutput = [
 		'\n   ' + chalk.green('1 passed') + time,
 		''
@@ -173,7 +173,7 @@ test('results with skipped tests', function (t) {
 	reporter.skipCount = 1;
 	reporter.failCount = 0;
 
-	var actualOutput = reporter.finish();
+	var actualOutput = reporter.finish({});
 	var expectedOutput = [
 		'\n   ' + chalk.yellow('1 skipped') + time,
 		''
@@ -189,7 +189,7 @@ test('results with todo tests', function (t) {
 	reporter.todoCount = 1;
 	reporter.failCount = 0;
 
-	var actualOutput = reporter.finish();
+	var actualOutput = reporter.finish({});
 	var expectedOutput = [
 		'\n   ' + chalk.blue('1 todo') + time,
 		''
@@ -204,7 +204,7 @@ test('results with passing skipped tests', function (t) {
 	reporter.passCount = 1;
 	reporter.skipCount = 1;
 
-	var output = reporter.finish().split('\n');
+	var output = reporter.finish({}).split('\n');
 
 	t.is(output[0], '');
 	t.is(output[1], '   ' + chalk.green('1 passed') + time);
@@ -320,13 +320,47 @@ test('results with errors', function (t) {
 	t.end();
 });
 
+test('results with 1 previous failure', function (t) {
+	var reporter = miniReporter();
+	reporter.todoCount = 1;
+
+	var runStatus = {
+		previousFailCount: 1
+	};
+
+	var output = reporter.finish(runStatus);
+	compareLineOutput(t, output, [
+		'',
+		'   ' + colors.todo('1 todo') + time,
+		'   ' + colors.error('1 previous failure in test files that were not rerun')
+	]);
+	t.end();
+});
+
+test('results with 2 previous failures', function (t) {
+	var reporter = miniReporter();
+	reporter.todoCount = 1;
+
+	var runStatus = {
+		previousFailCount: 2
+	};
+
+	var output = reporter.finish(runStatus);
+	compareLineOutput(t, output, [
+		'',
+		'   ' + colors.todo('1 todo') + time,
+		'   ' + colors.error('2 previous failures in test files that were not rerun')
+	]);
+	t.end();
+});
+
 test('empty results after reset', function (t) {
 	var reporter = miniReporter();
 
 	reporter.failCount = 1;
 	reporter.reset();
 
-	var output = reporter.finish();
+	var output = reporter.finish({});
 	t.is(output, '\n');
 	t.end();
 });

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -341,6 +341,42 @@ test('results with errors', function (t) {
 	t.end();
 });
 
+test('results with 1 previous failure', function (t) {
+	var reporter = createReporter();
+
+	var runStatus = createRunStatus();
+	runStatus.passCount = 1;
+	runStatus.exceptionCount = 1;
+	runStatus.previousFailCount = 1;
+
+	var output = reporter.finish(runStatus);
+	compareLineOutput(t, output, [
+		'',
+		'  ' + colors.pass('1 test passed') + time,
+		'  ' + colors.error('1 uncaught exception'),
+		'  ' + colors.error('1 previous failure in test files that were not rerun')
+	]);
+	t.end();
+});
+
+test('results with 2 previous failures', function (t) {
+	var reporter = createReporter();
+
+	var runStatus = createRunStatus();
+	runStatus.passCount = 1;
+	runStatus.exceptionCount = 1;
+	runStatus.previousFailCount = 2;
+
+	var output = reporter.finish(runStatus);
+	compareLineOutput(t, output, [
+		'',
+		'  ' + colors.pass('1 test passed') + time,
+		'  ' + colors.error('1 uncaught exception'),
+		'  ' + colors.error('2 previous failures in test files that were not rerun')
+	]);
+	t.end();
+});
+
 test('full-width line when sectioning', function (t) {
 	var reporter = createReporter();
 


### PR DESCRIPTION
Fixes #699. The watcher tracks how many failures (actual failures, but also rejections and uncaught exceptions) occurred for each test file. After each run, if there are failures from files that were not rerun, the count is added to the logger output.