### PR TITLE
compute cache salt using package-hash

### DIFF
--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -6,6 +6,7 @@ var cachingTransform = require('caching-transform');
 var objectAssign = require('object-assign');
 var stripBom = require('strip-bom');
 var md5Hex = require('md5-hex');
+var packageHash = require('package-hash');
 var enhanceAssert = require('./enhance-assert');
 
 function CachingPrecompiler(cacheDirPath, babelConfig) {
@@ -159,14 +160,11 @@ CachingPrecompiler.prototype._createEspowerPlugin = function () {
 };
 
 CachingPrecompiler.prototype._createTransform = function () {
-	var dependencies = {
-		'babel-plugin-espower': require('babel-plugin-espower/package.json').version,
-		'ava': require('../package.json').version,
-		'babel-core': require('babel-core/package.json').version,
-		'babelConfig': this.babelConfig
-	};
-
-	var salt = new Buffer(JSON.stringify(dependencies));
+	var salt = packageHash.sync([
+		require.resolve('../package.json'),
+		require.resolve('babel-core/package.json'),
+		require.resolve('babel-plugin-espower/package.json')
+	], JSON.stringify(this.babelConfig));
 
 	return cachingTransform({
 		factory: this._factory,

--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -14,7 +14,7 @@ function CachingPrecompiler(cacheDirPath, babelConfig) {
 		throw new TypeError('Class constructor CachingPrecompiler cannot be invoked without \'new\'');
 	}
 
-	this.babelConfig = babelConfig;
+	this.babelConfig = babelConfig || 'default';
 	this.cacheDirPath = cacheDirPath;
 	this.fileHashes = {};
 
@@ -94,7 +94,7 @@ CachingPrecompiler.prototype._transform = function (code, filePath, hash) {
 CachingPrecompiler.prototype._buildOptions = function (filePath, code) {
 	var options = {babelrc: false};
 
-	if (!this.babelConfig || this.babelConfig === 'default') {
+	if (this.babelConfig === 'default') {
 		objectAssign(options, {presets: this.defaultPresets});
 	} else if (this.babelConfig === 'inherit') {
 		objectAssign(options, {babelrc: true});

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "observable-to-promise": "^0.3.0",
     "only-shallow": "^1.2.0",
     "option-chain": "^0.1.0",
+    "package-hash": "^1.1.0",
     "pkg-conf": "^1.0.1",
     "plur": "^2.0.0",
     "power-assert-formatter": "^1.3.0",


### PR DESCRIPTION
I just wrote <https://github.com/novemberborn/package-hash> which is a more powerful way of computing hashes for packages. It includes the GIt repo state which is very useful during development. Say if you're hacking on AVA and `npm link` it into a test project, now you don't need to clear the AVA cache in your test project whenever you make changes to AVA.

Feedback welcome!