### PR TITLE
Fix region dependent test failures.

### DIFF
--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -29,7 +29,7 @@ function miniReporter() {
 
 process.stderr.setMaxListeners(50);
 
-lolex.install(new Date('2014-11-19T00:19:12+0700').getTime(), ['Date']);
+lolex.install(new Date(2014, 11, 19, 17, 19, 12, 200).getTime(), ['Date']);
 var time = ' ' + chalk.grey.dim('[17:19:12]');
 
 test('start', function (t) {

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -15,7 +15,7 @@ chalk.enabled = true;
 // undefined. Expect an 80 character wide line to be rendered.
 var fullWidthLine = chalk.gray.dim(repeating('\u2500', 80));
 
-lolex.install(new Date('2014-11-19T00:19:12+0700').getTime(), ['Date']);
+lolex.install(new Date(2014, 11, 19, 17, 19, 12, 200).getTime(), ['Date']);
 var time = ' ' + chalk.grey.dim('[17:19:12]');
 
 function createReporter() {


### PR DESCRIPTION
This mocks time using the region dependent Date constructor, so reporter output always shows the same time regardless.

non-controversial, so I will be merging as soon as I verify Travis passes