### PR TITLE
presets example documentation fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -539,7 +539,7 @@ The corresponding Babel config for AVA's setup is as follows:
 {
   "presets": [
     "es2015",
-    "stage-2",
+    "stage-2"
   ],
   "plugins": [
     "espower",


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/sindresorhus/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

There was a trailing comma after the es2015 "presets" key.