### PR TITLE
Removed stray characters from CLI sample output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ $ ava --help
     --tap, -t        Generate TAP output
     --verbose, -v    Enable verbose output
     --no-cache       Disable the transpiler cache
-    --match, -m      Only run tests with matching title (Can be repeated)',
+    --match, -m      Only run tests with matching title (Can be repeated)
     --watch, -w      Re-run tests when tests and source files change
     --source, -S     Pattern to match source files so tests can be re-run (Can be repeated)
     --timeout, -T    Set global timeout


### PR DESCRIPTION
The sample CLI output in the readme was presumably copied from the source in cli.js, but a single quote and comma seems to have been left behind.