### PR TITLE
Throwing synchronously inside a callback style test should fail it immediately.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -36,6 +36,7 @@ function Test(title, fn, contextRef, report) {
 	this.sync = true;
 	this.contextRef = contextRef;
 	this.report = report;
+	this.threwSync = false;
 
 	// TODO(jamestalmage): make this an optional constructor arg instead of having Runner set it after the fact.
 	// metadata should just always exist, otherwise it requires a bunch of ugly checks all over the place.
@@ -95,6 +96,7 @@ Test.prototype._run = function () {
 	try {
 		ret = this.fn(this._publicApi());
 	} catch (err) {
+		this.threwSync = true;
 		if (err instanceof Error) {
 			this._setAssertError(err);
 		} else {
@@ -176,7 +178,7 @@ Test.prototype.run = function () {
 		return this.promise().promise;
 	}
 
-	if (this.metadata.callback) {
+	if (this.metadata.callback && !this.threwSync) {
 		return this.promise().promise;
 	}
 
@@ -214,7 +216,8 @@ Test.prototype._end = function (err) {
 	}
 
 	if (this.endCalled) {
-		throw new Error('.end() called more than once');
+		this._setAssertError(new Error('.end() called more than once'));
+		return;
 	}
 
 	this.endCalled = true;
@@ -239,7 +242,7 @@ Test.prototype.exit = function () {
 
 	this._checkPlanCount();
 
-	if (this.sync) {
+	if (this.sync || this.threwSync) {
 		self.duration = globals.now() - self._timeStart;
 		globals.clearTimeout(self._timeout);
 

--- a/test/test.js
+++ b/test/test.js
@@ -433,6 +433,27 @@ test('throws and notThrows work with promises', function (t) {
 	});
 });
 
+test('end should not be called multiple times', function (t) {
+	ava.cb(function (a) {
+		a.end();
+		a.end();
+	}).run().then(function (result) {
+		t.is(result.passed, false);
+		t.is(result.reason.message, '.end() called more than once');
+		t.end();
+	});
+});
+
+test('cb test that throws sync', function (t) {
+	var result = ava.cb(function () {
+		throw new Error('foo');
+	}).run();
+
+	t.is(result.passed, false);
+	t.is(result.reason.message, 'foo');
+	t.end();
+});
+
 test('waits for t.throws to resolve after t.end is called', function (t) {
 	ava.cb(function (a) {
 		a.plan(1);


### PR DESCRIPTION
Fixes #748.