### PR TITLE
chore(pkg): remove duplicate babel-code-frame dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "update-notifier": "^0.6.0"
   },
   "devDependencies": {
-    "babel-code-frame": "^6.7.5",
     "cli-table2": "^0.2.0",
     "coveralls": "^2.11.4",
     "delay": "^1.3.0",


### PR DESCRIPTION
Hi

Looking at the `ava` dependencies I spotted a double `babel-code-frame` [L86](https://github.com/sindresorhus/ava/blob/d6acdde056238d5e7403e63413b63a39dd61ff6a/package.json#L86) and [L151](https://github.com/sindresorhus/ava/blob/d6acdde056238d5e7403e63413b63a39dd61ff6a/package.json#L151)

No problem with removing the one in the devDependencies ?

