### PR TITLE
Strip ANSI escape codes in TAP test titles

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -1,5 +1,6 @@
 'use strict';
 var format = require('util').format;
+var stripANSI = require('strip-ansi');
 
 // Parses stack trace and extracts original function name, file name and line.
 function getSourceFromStack(stack, index) {
@@ -36,10 +37,12 @@ TapReporter.prototype.test = function (test) {
 		directive = '# SKIP';
 	}
 
+	var strippedTitle = stripANSI(test.title);
+
 	if (test.error) {
 		output = [
-			'# ' + test.title,
-			format('not ok %d - %s', ++this.i, test.title),
+			'# ' + strippedTitle,
+			format('not ok %d - %s', ++this.i, strippedTitle),
 			'  ---',
 			'    operator: ' + test.error.operator,
 			'    expected: ' + test.error.expected,
@@ -49,8 +52,8 @@ TapReporter.prototype.test = function (test) {
 		];
 	} else {
 		output = [
-			'# ' + test.title,
-			format('%s %d - %s %s', passed, ++this.i, test.title, directive).trim()
+			'# ' + strippedTitle,
+			format('%s %d - %s %s', passed, ++this.i, strippedTitle, directive).trim()
 		];
 	}
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -1,6 +1,6 @@
 'use strict';
 var format = require('util').format;
-var stripANSI = require('strip-ansi');
+var stripAnsi = require('strip-ansi');
 
 // Parses stack trace and extracts original function name, file name and line.
 function getSourceFromStack(stack, index) {
@@ -37,12 +37,12 @@ TapReporter.prototype.test = function (test) {
 		directive = '# SKIP';
 	}
 
-	var strippedTitle = stripANSI(test.title);
+	var title = stripAnsi(test.title);
 
 	if (test.error) {
 		output = [
-			'# ' + strippedTitle,
-			format('not ok %d - %s', ++this.i, strippedTitle),
+			'# ' + title,
+			format('not ok %d - %s', ++this.i, title),
 			'  ---',
 			'    operator: ' + test.error.operator,
 			'    expected: ' + test.error.expected,
@@ -52,8 +52,8 @@ TapReporter.prototype.test = function (test) {
 		];
 	} else {
 		output = [
-			'# ' + strippedTitle,
-			format('%s %d - %s %s', passed, ++this.i, strippedTitle, directive).trim()
+			'# ' + title,
+			format('%s %d - %s %s', passed, ++this.i, title, directive).trim()
 		];
 	}
 

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "delay": "^1.3.0",
     "get-stream": "^2.0.0",
     "git-branch": "^0.3.0",
+    "has-ansi": "^2.0.0",
     "inquirer": "^1.0.2",
     "lolex": "^1.4.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "slash": "^1.0.0",
     "source-map-support": "^0.4.0",
     "stack-utils": "^0.4.0",
+    "strip-ansi": "^3.0.1",
     "strip-bom": "^2.0.0",
     "time-require": "^0.1.2",
     "unique-temp-dir": "^1.0.0",

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -190,7 +190,7 @@ test('reporter strips ANSI characters', function (t) {
 	  file: 'test.js'
 	};
 
-	var output = reporter.test(test)
+	var output = reporter.test(test);
 
 	t.notOk(hasAnsi(output.title));
 	t.end();

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -186,7 +186,7 @@ test('reporter strips ANSI characters', function (t) {
 	var reporter = tapReporter();
 
 	var output = reporter.test({
-		title: chalk.gray.dim('test ' + chalk.gray.dim('›') + ' my test'),
+		title: 'test ' + chalk.gray.dim('›') + ' my test',
 		type: 'test',
 		file: 'test.js'
 	});

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -1,5 +1,6 @@
 'use strict';
 var test = require('tap').test;
+var hasAnsi = require('has-ansi');
 var tapReporter = require('../../lib/reporters/tap');
 
 test('start', function (t) {
@@ -177,5 +178,20 @@ test('skip test', function (t) {
 	].join('\n');
 
 	t.is(actualOutput, expectedOutput);
+	t.end();
+});
+
+test('reporter strips ANSI characters', function (t) {
+	var reporter = tapReporter();
+
+	var test = {
+	  title: 'test \u001b[90m\u001b[2m›\u001b[22m\u001b[39m my test',
+	  type: 'test',
+	  file: 'test.js'
+	};
+
+	var output = reporter.test(test)
+
+	t.notOk(hasAnsi(output.title));
 	t.end();
 });

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -185,9 +185,9 @@ test('reporter strips ANSI characters', function (t) {
 	var reporter = tapReporter();
 
 	var test = {
-	  title: 'test \u001b[90m\u001b[2m›\u001b[22m\u001b[39m my test',
-	  type: 'test',
-	  file: 'test.js'
+		title: 'test \u001b[90m\u001b[2m›\u001b[22m\u001b[39m my test',
+		type: 'test',
+		file: 'test.js'
 	};
 
 	var output = reporter.test(test);

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -1,6 +1,7 @@
 'use strict';
 var test = require('tap').test;
 var hasAnsi = require('has-ansi');
+var chalk = require('chalk');
 var tapReporter = require('../../lib/reporters/tap');
 
 test('start', function (t) {
@@ -184,13 +185,11 @@ test('skip test', function (t) {
 test('reporter strips ANSI characters', function (t) {
 	var reporter = tapReporter();
 
-	var test = {
-		title: 'test \u001b[90m\u001b[2m›\u001b[22m\u001b[39m my test',
+	var output = reporter.test({
+		title: chalk.gray.dim('test \u001b[90m\u001b[2m›\u001b[22m\u001b[39m my test'),
 		type: 'test',
 		file: 'test.js'
-	};
-
-	var output = reporter.test(test);
+	});
 
 	t.notOk(hasAnsi(output.title));
 	t.end();

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -186,7 +186,7 @@ test('reporter strips ANSI characters', function (t) {
 	var reporter = tapReporter();
 
 	var output = reporter.test({
-		title: chalk.gray.dim('test \u001b[90m\u001b[2m›\u001b[22m\u001b[39m my test'),
+		title: chalk.gray.dim('test ' + chalk.gray.dim('›') + ' my test'),
 		type: 'test',
 		file: 'test.js'
 	});


### PR DESCRIPTION
Fixes issue mentioned by @xjamundx in #723.