### PR TITLE
Use Babel's compact mode. Fixes #790

### DIFF
--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -108,7 +108,9 @@ CachingPrecompiler.prototype._buildOptions = function (filePath, code) {
 		inputSourceMap: sourceMap,
 		filename: filePath,
 		sourceMaps: true,
-		ast: false
+		ast: false,
+		compact: true,
+		comments: false
 	});
 
 	options.plugins = (options.plugins || []).concat(this.defaultPlugins);

--- a/test/cli.js
+++ b/test/cli.js
@@ -95,7 +95,7 @@ test('timeout', function (t) {
 test('throwing a named function will report the to the console', function (t) {
 	execCli('fixture/throw-named-function.js', function (err, stdout, stderr) {
 		t.ok(err);
-		t.match(stderr, /function fooFn\(\) \{\}/);
+		t.match(stderr, /function fooFn\(\)\{\}/);
 		// TODO(jamestalmage)
 		// t.ok(/1 uncaught exception[^s]/.test(stdout));
 		t.end();
@@ -140,7 +140,7 @@ test('babel require hook only applies to the test file', function (t) {
 test('throwing a anonymous function will report the function to the console', function (t) {
 	execCli('fixture/throw-anonymous-function.js', function (err, stdout, stderr) {
 		t.ok(err);
-		t.match(stderr, /function \(\) \{\}/);
+		t.match(stderr, /function \(\)\{\}/);
 		// TODO(jamestalmage)
 		// t.ok(/1 uncaught exception[^s]/.test(stdout));
 		t.end();


### PR DESCRIPTION
Fixes #790.
Add new options to Babel: `compact: true` and `comment: false`.

I had to fix some tests, as the whitespace in the tested output was removed. (I thought about adding a `?` to make the whitespace optional, but this is probably better I think)

I ran the bench tests, but I don't feel like there's a lot of change performance-wise (both tests run in ~5 minutes on my machine). Is this part of what the bench tests are testing?

Note that it changes the error output from
![image](https://cloud.githubusercontent.com/assets/3869412/14902028/bcabda16-0d98-11e6-819a-3e51e8295f68.png)
to
![image](https://cloud.githubusercontent.com/assets/3869412/14902011/a985a138-0d98-11e6-9e9c-6f483d6924d1.png)
(though in this case, I prefer the new version :smile:)


<!--

Read the [contributing guidelines](https://github.com/sindresorhus/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->