### PR TITLE
Fix `npm link` usage on Node.js 6

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -31,9 +31,29 @@ module.exports = function (file, opts) {
 		} : false
 	}, opts);
 
-	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
-		cwd: path.dirname(file),
-		silent: true,
+	var execArgv = process.execArgv;
+	var cwd = path.dirname(file);
+
+	// This is straight out of node child_process
+	if (process._eval != null) { // eslint-disable-line
+		var index = execArgv.lastIndexOf(process._eval);
+		if (index > 0) {
+			// Remove the -e switch to avoid fork bombing ourselves.
+			execArgv = execArgv.slice();
+			execArgv.splice(index - 1, 2);
+		}
+	}
+
+	var args = execArgv.concat([
+		'-e',
+		'require("ava/lib/test-worker")',
+		path.join(__dirname, 'test-worker.js'),
+		JSON.stringify(opts)
+	]);
+
+	var ps = childProcess.spawn(process.execPath, args, {
+		cwd: cwd,
+		stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
 		env: env
 	});
 

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -31,10 +31,14 @@ module.exports = function (file, opts) {
 		} : false
 	}, opts);
 
+	// Workaround for breakage caused by https://github.com/nodejs/node/pull/5950
+	// Those changes will be reverted in https://github.com/nodejs/node/pull/6537
+
+	// Revert #815 when these changes land in Node.js
 	var execArgv = process.execArgv;
 	var cwd = path.dirname(file);
 
-	// This is straight out of node child_process
+	// This whole if statement is copied straight out of Nodes `child_process`
 	if (process._eval != null) { // eslint-disable-line
 		var index = execArgv.lastIndexOf(process._eval);
 		if (index > 0) {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -44,10 +44,12 @@ module.exports = function (file, opts) {
 		}
 	}
 
+	var testWorkerPath = path.join(__dirname, 'test-worker.js');
+
 	var args = execArgv.concat([
 		'-e',
-		'require("ava/lib/test-worker")',
-		path.join(__dirname, 'test-worker.js'),
+		'require(' + JSON.stringify(testWorkerPath) + ')',
+		testWorkerPath,
 		JSON.stringify(opts)
 	]);
 


### PR DESCRIPTION
Fixes #814, but causes all sorts of test breakage.

I can't really figure out why it breaks the tests, it seems to work fine IRL. My only guess is that being wrapped by `tap` is somehow causing the problem.