### PR TITLE
fix crash in 'fake' browser env

### DIFF
--- a/lib/test-worker.js
+++ b/lib/test-worker.js
@@ -48,6 +48,7 @@ Promise.longStackTraces();
 var sourceMapCache = Object.create(null);
 
 sourceMapSupport.install({
+	environment: 'node',
 	handleUncaughtExceptions: false,
 	retrieveSourceMap: function (source) {
 		if (sourceMapCache[source]) {

--- a/test/api.js
+++ b/test/api.js
@@ -384,6 +384,27 @@ function generateTests(prefix, apiCreator) {
 			});
 	});
 
+	test(prefix + 'stack traces for exceptions are corrected using a source map file in what looks like a browser env', function (t) {
+		t.plan(4);
+
+		var api = apiCreator({
+			cacheEnabled: true
+		});
+
+		api.on('test-run', function (runStatus) {
+			runStatus.on('error', function (data) {
+				t.match(data.message, /Thrown by source-map-fixtures/);
+				t.match(data.stack, /^.*?Object\.t.*?as run\b.*source-map-fixtures.src.throws.js:1.*$/m);
+				t.match(data.stack, /^.*?Immediate\b.*source-map-file-browser-env.js:14.*$/m);
+			});
+		});
+
+		api.run([path.join(__dirname, 'fixture/source-map-file-browser-env.js')])
+			.then(function (result) {
+				t.is(result.passCount, 1);
+			});
+	});
+
 	test(prefix + 'stack traces for exceptions are corrected using a source map file (cache off)', function (t) {
 		t.plan(4);
 

--- a/test/fixture/source-map-file-browser-env.js
+++ b/test/fixture/source-map-file-browser-env.js
@@ -1,0 +1,14 @@
+const fixture = require('source-map-fixtures').mapFile('throws').require();
+const test = require('../../');
+
+global.window = function () {};
+global.XMLHttpRequest = function () {};
+
+// The uncaught exception is passed to the corresponding cli test. The line
+// numbers from the 'throws' fixture (which uses a map file), as well as the
+// line of the fixture.run() call, should match the source lines.
+test('throw an uncaught exception', () => {
+	setImmediate(run);
+});
+
+const run = () => fixture.run();


### PR DESCRIPTION
closes #822 

- I've added a failing test. basically just copied one of the existing source map fixtures and added the two lines that make `source-map-support` think it's a browser env. I'm not sure I added the test in the right place, do let me know if it should go somewhere else.
```js
global.window = function () {};
global.XMLHttpRequest = function () {};
```
- I've also added the option @novemberborn mentioned on https://github.com/sindresorhus/ava/issues/822#issuecomment-218703506 to `sourceMapSupport.install()` to fix the bug