### PR TITLE
Basic macro support.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -69,6 +69,38 @@ optionChain(chainableMethods, function (opts, args) {
 		macroArgIndex = 1;
 	}
 
+	if (this._serial) {
+		opts.serial = true;
+	}
+
+	if (opts.type === 'test' && this._match.length > 0) {
+		opts.exclusive = title !== null && matcher([title], this._match).length === 1;
+	}
+
+	if (args.length > macroArgIndex) {
+		args = args.slice(macroArgIndex);
+	} else {
+		args = null;
+	}
+
+	this._addTest(title, opts, fn, args);
+}, Runner.prototype);
+
+function wrapFunction(fn, args) {
+	return function (t) {
+		return fn.apply(this, [t].concat(args));
+	};
+}
+
+Runner.prototype._addTest = function (title, opts, fn, args) {
+	if (args) {
+		if (!title && fn.title) {
+			title = fn.title.apply(fn, args);
+		}
+
+		fn = wrapFunction(fn, args);
+	}
+
 	if (opts.todo) {
 		if (typeof fn === 'function') {
 			throw new TypeError('`todo` tests are not allowed to have an implementation. Use `test.skip()` for tests with an implementation.');
@@ -83,34 +115,12 @@ optionChain(chainableMethods, function (opts, args) {
 		throw new TypeError('Expected an implementation. Use `test.todo()` for tests without an implementation.');
 	}
 
-	if (this._serial) {
-		opts.serial = true;
-	}
-
-	if (opts.type === 'test' && this._match.length > 0) {
-		opts.exclusive = title !== null && matcher([title], this._match).length === 1;
-	}
-
-	if (args.length > macroArgIndex) {
-		args = args.slice(macroArgIndex);
-
-		if (!title && fn.title) {
-			title = fn.title(args);
-		}
-
-		var _fn = fn;
-
-		fn = function (t) {
-			return _fn.apply(this, [t, args]);
-		};
-	}
-
 	this.tests.add({
 		metadata: opts,
 		fn: fn,
 		title: title
 	});
-}, Runner.prototype);
+};
 
 Runner.prototype._addTestResult = function (result) {
 	var test = result.result;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -73,17 +73,19 @@ optionChain(chainableMethods, function (opts, args) {
 		opts.serial = true;
 	}
 
-	if (opts.type === 'test' && this._match.length > 0) {
-		opts.exclusive = title !== null && matcher([title], this._match).length === 1;
-	}
-
 	if (args.length > macroArgIndex) {
 		args = args.slice(macroArgIndex);
 	} else {
 		args = null;
 	}
 
-	this._addTest(title, opts, fn, args);
+	if (Array.isArray(fn)) {
+		fn.forEach(function (fn) {
+			this._addTest(title, opts, fn, args);
+		}, this);
+	} else {
+		this._addTest(title, opts, fn, args);
+	}
 }, Runner.prototype);
 
 function wrapFunction(fn, args) {
@@ -99,6 +101,10 @@ Runner.prototype._addTest = function (title, opts, fn, args) {
 		}
 
 		fn = wrapFunction(fn, args);
+	}
+
+	if (opts.type === 'test' && this._match.length > 0) {
+		opts.exclusive = title !== null && matcher([title], this._match).length === 1;
 	}
 
 	if (opts.todo) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -9,7 +9,6 @@ var TestCollection = require('./test-collection');
 function noop() {}
 
 var chainableMethods = {
-	spread: true,
 	defaults: {
 		type: 'test',
 		serial: false,
@@ -55,10 +54,19 @@ function Runner(options) {
 util.inherits(Runner, EventEmitter);
 module.exports = Runner;
 
-optionChain(chainableMethods, function (opts, title, fn) {
-	if (typeof title === 'function') {
-		fn = title;
+optionChain(chainableMethods, function (opts, args) {
+	var title;
+	var fn;
+	var macroArgIndex;
+
+	if (typeof args[0] === 'string') {
+		title = args[0];
+		fn = args[1];
+		macroArgIndex = 2;
+	} else {
+		fn = args[0];
 		title = null;
+		macroArgIndex = 1;
 	}
 
 	if (opts.todo) {
@@ -81,6 +89,20 @@ optionChain(chainableMethods, function (opts, title, fn) {
 
 	if (opts.type === 'test' && this._match.length > 0) {
 		opts.exclusive = title !== null && matcher([title], this._match).length === 1;
+	}
+
+	if (args.length > macroArgIndex) {
+		args = args.slice(macroArgIndex);
+
+		if (!title && fn.title) {
+			title = fn.title(args);
+		}
+
+		var _fn = fn;
+
+		fn = function (t) {
+			return _fn.apply(this, [t, args]);
+		};
 	}
 
 	this.tests.add({

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -96,8 +96,8 @@ function wrapFunction(fn, args) {
 
 Runner.prototype._addTest = function (title, opts, fn, args) {
 	if (args) {
-		if (!title && fn.title) {
-			title = fn.title.apply(fn, args);
+		if (fn.title) {
+			title = fn.title.apply(fn, [title || ''].concat(args));
 		}
 
 		fn = wrapFunction(fn, args);

--- a/readme.md
+++ b/readme.md
@@ -544,11 +544,14 @@ function macro(t, input, expected) {
 	t.is(eval(input), expected);
 }
 
-macro.title = (input, expected) => `${input} === ${expected}`;
+macro.title = (providedTitle, input, expected) => `${providedTitle} ${input} === ${expected}`.trim();
 
 test(macro, '2 + 2', 4);
 test(macro, '2 * 3', 6);
+test('providedTitle', macro, '3 * 3', 9);
 ```
+
+The `providedTitle` argument defaults to an empty string if the user does not supply a string title. This allows for easy concatenation without having to worry about `null` / `undefined`. It is worth remembering that the empty string is considered a falsy value, so you can still use `if(providedTitle)`.
 
 You can also pass arrays of macro functions:
 

--- a/readme.md
+++ b/readme.md
@@ -550,6 +550,23 @@ test(macro, '2 + 2', 4);
 test(macro, '2 * 3', 6);
 ```
 
+You can also pass arrays of macro functions:
+
+```js
+var safeEval = require('safe-eval');
+
+function evalMacro(t, input, expected) {
+	t.is(eval(input), expected);
+}
+
+function safeEvalMacro(t, input, expected) {
+	t.is(safeEval(input), expected);
+}
+
+test([evalMacro, safeEvalMacro], '2 + 2', 4);
+test([evalMacro, safeEvalMacro], '2 * 3', 6);
+```
+
 
 ### Custom assertions
 

--- a/readme.md
+++ b/readme.md
@@ -551,12 +551,12 @@ test(macro, '2 * 3', 6);
 test('providedTitle', macro, '3 * 3', 9);
 ```
 
-The `providedTitle` argument defaults to an empty string if the user does not supply a string title. This allows for easy concatenation without having to worry about `null` / `undefined`. It is worth remembering that the empty string is considered a falsy value, so you can still use `if(providedTitle)`.
+The `providedTitle` argument defaults to an empty string if the user does not supply a string title. This allows for easy concatenation without having to worry about `null` / `undefined`. It is worth remembering that the empty string is considered a falsy value, so you can still use `if(providedTitle) {...}`.
 
 You can also pass arrays of macro functions:
 
 ```js
-var safeEval = require('safe-eval');
+const safeEval = require('safe-eval');
 
 function evalMacro(t, input, expected) {
 	t.is(eval(input), expected);
@@ -570,6 +570,7 @@ test([evalMacro, safeEvalMacro], '2 + 2', 4);
 test([evalMacro, safeEvalMacro], '2 * 3', 6);
 ```
 
+We encourage you to use macros instead of building your own test generators ([here is an example](https://github.com/jamestalmage/ava-codemods/blob/47073b5b58aa6f3fb24f98757be5d3f56218d160/test/ok-to-truthy.js#L7-L9) of code that should be replaced with a macro). Macros are designed to perform static analysis of your code, which can lead to better performance, IDE integration, and linter rules.
 
 ### Custom assertions
 

--- a/readme.md
+++ b/readme.md
@@ -524,6 +524,33 @@ test.only.serial(...);
 
 This means you can temporarily add `.skip` or `.only` at the end of a test or hook definition without having to make any other changes.
 
+### Test macros
+
+Additional arguments after the test function will be passed as an array to the test function. This is useful for creating reusable test macros.
+
+```js
+function macro(t, [input, expected]) {
+  t.is(eval(input), expected);
+}
+
+test('2 + 2 === 4', macro, '2 + 2', 4);
+test('2 * 3 === 6', macro, '2 * 3', 6);
+```
+
+You can build the test title programatically by attaching a `title` function to the macro:
+
+ ```js
+ function macro(t, [input, expected]) {
+   t.is(eval(input), expected);
+ }
+
+ macro.title = ([input, expected]) => `${input} === ${expected}`;
+
+ test(macro, '2 + 2', 4);
+ test(macro, '2 * 3', 6);
+ ```
+
+
 ### Custom assertions
 
 You can use any assertion library instead of or in addition to the built-in one, provided it throws exceptions when the assertion fails.

--- a/readme.md
+++ b/readme.md
@@ -530,7 +530,7 @@ Additional arguments after the test function will be passed as an array to the t
 
 ```js
 function macro(t, [input, expected]) {
-  t.is(eval(input), expected);
+	t.is(eval(input), expected);
 }
 
 test('2 + 2 === 4', macro, '2 + 2', 4);
@@ -539,16 +539,16 @@ test('2 * 3 === 6', macro, '2 * 3', 6);
 
 You can build the test title programatically by attaching a `title` function to the macro:
 
- ```js
- function macro(t, [input, expected]) {
-   t.is(eval(input), expected);
- }
+```js
+function macro(t, [input, expected]) {
+	t.is(eval(input), expected);
+}
 
- macro.title = ([input, expected]) => `${input} === ${expected}`;
+macro.title = ([input, expected]) => `${input} === ${expected}`;
 
- test(macro, '2 + 2', 4);
- test(macro, '2 * 3', 6);
- ```
+test(macro, '2 + 2', 4);
+test(macro, '2 * 3', 6);
+```
 
 
 ### Custom assertions

--- a/readme.md
+++ b/readme.md
@@ -526,10 +526,10 @@ This means you can temporarily add `.skip` or `.only` at the end of a test or ho
 
 ### Test macros
 
-Additional arguments after the test function will be passed as an array to the test function. This is useful for creating reusable test macros.
+Additional arguments passed to the test declaration will be passed to the test implementation. This is useful for creating reusable test macros.
 
 ```js
-function macro(t, [input, expected]) {
+function macro(t, input, expected) {
 	t.is(eval(input), expected);
 }
 
@@ -537,14 +537,14 @@ test('2 + 2 === 4', macro, '2 + 2', 4);
 test('2 * 3 === 6', macro, '2 * 3', 6);
 ```
 
-You can build the test title programatically by attaching a `title` function to the macro:
+You can build the test title programmatically by attaching a `title` function to the macro:
 
 ```js
-function macro(t, [input, expected]) {
+function macro(t, input, expected) {
 	t.is(eval(input), expected);
 }
 
-macro.title = ([input, expected]) => `${input} === ${expected}`;
+macro.title = (input, expected) => `${input} === ${expected}`;
 
 test(macro, '2 + 2', 4);
 test(macro, '2 * 3', 6);

--- a/test/runner.js
+++ b/test/runner.js
@@ -2,6 +2,7 @@
 var test = require('tap').test;
 var Runner = require('../lib/runner');
 
+var slice = Array.prototype.slice;
 var noop = function () {};
 
 test('must be called with new', function (t) {
@@ -474,8 +475,8 @@ test('additional args will be passed as an array', function (t) {
 
 	var runner = new Runner();
 
-	runner.test('test1', function (avaT, args) {
-		t.deepEqual(args, ['foo', 'bar']);
+	runner.test('test1', function () {
+		t.deepEqual(slice.call(arguments, 1), ['foo', 'bar']);
 	}, 'foo', 'bar');
 
 	runner.run({}).then(function (stats) {
@@ -500,13 +501,13 @@ test('macro functions can be named by attaching a custom function', function (t)
 		['C']
 	];
 
-	function macroFn(avaT, args) {
+	function macroFn(avaT) {
 		t.is(avaT.title, expectedTitles.shift());
-		t.deepEqual(args, expectedArgs.shift());
+		t.deepEqual(slice.call(arguments, 1), expectedArgs.shift());
 	}
 
-	macroFn.title = function (args) {
-		return 'title' + args[0];
+	macroFn.title = function (firstArg) {
+		return 'title' + firstArg;
 	};
 
 	var runner = new Runner();

--- a/test/runner.js
+++ b/test/runner.js
@@ -468,3 +468,56 @@ test('options.match overrides .only', function (t) {
 		t.end();
 	});
 });
+
+test('additional args will be passed as an array', function (t) {
+	t.plan(3);
+
+	var runner = new Runner();
+
+	runner.test('test1', function (avaT, args) {
+		t.deepEqual(args, ['foo', 'bar']);
+	}, 'foo', 'bar');
+
+	runner.run({}).then(function (stats) {
+		t.is(stats.passCount, 1);
+		t.is(stats.testCount, 1);
+		t.end();
+	});
+});
+
+test('macro functions can be named by attaching a custom function', function (t) {
+	t.plan(8);
+
+	var expectedTitles = [
+		'titleA',
+		'overridden',
+		'titleC'
+	];
+
+	var expectedArgs = [
+		['A'],
+		['B'],
+		['C']
+	];
+
+	function macroFn(avaT, args) {
+		t.is(avaT.title, expectedTitles.shift());
+		t.deepEqual(args, expectedArgs.shift());
+	}
+
+	macroFn.title = function (args) {
+		return 'title' + args[0];
+	};
+
+	var runner = new Runner();
+
+	runner.test(macroFn, 'A');
+	runner.test('overridden', macroFn, 'B');
+	runner.test(macroFn, 'C');
+
+	runner.run({}).then(function (stats) {
+		t.is(stats.passCount, 3);
+		t.is(stats.testCount, 3);
+		t.end();
+	});
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -470,7 +470,7 @@ test('options.match overrides .only', function (t) {
 	});
 });
 
-test('additional args will be passed as an array', function (t) {
+test('macros: Additional args will be spread as additional args on implementation function', function (t) {
 	t.plan(3);
 
 	var runner = new Runner();
@@ -486,13 +486,13 @@ test('additional args will be passed as an array', function (t) {
 	});
 });
 
-test('macro functions can be named by attaching a custom function', function (t) {
+test('macros: Customize test names attaching a `title` function', function (t) {
 	t.plan(8);
 
 	var expectedTitles = [
-		'titleA',
-		'overridden',
-		'titleC'
+		'defaultA',
+		'suppliedB',
+		'defaultC'
 	];
 
 	var expectedArgs = [
@@ -506,14 +506,14 @@ test('macro functions can be named by attaching a custom function', function (t)
 		t.deepEqual(slice.call(arguments, 1), expectedArgs.shift());
 	}
 
-	macroFn.title = function (firstArg) {
-		return 'title' + firstArg;
+	macroFn.title = function (title, firstArg) {
+		return (title || 'default') + firstArg;
 	};
 
 	var runner = new Runner();
 
 	runner.test(macroFn, 'A');
-	runner.test('overridden', macroFn, 'B');
+	runner.test('supplied', macroFn, 'B');
 	runner.test(macroFn, 'C');
 
 	runner.run({}).then(function (stats) {
@@ -530,7 +530,7 @@ test('match applies to macros', function (t) {
 		t.is(avaT.title, 'foobar');
 	}
 
-	macroFn.title = function (firstArg) {
+	macroFn.title = function (title, firstArg) {
 		return firstArg + 'bar';
 	};
 
@@ -592,14 +592,14 @@ test('match applies to arrays of macros', function (t) {
 	function fooMacro() {
 		t.fail();
 	}
-	fooMacro.title = function (firstArg) {
+	fooMacro.title = function (title, firstArg) {
 		return firstArg + 'foo';
 	};
 
 	function barMacro(avaT) {
 		t.is(avaT.title, 'foobar');
 	}
-	barMacro.title = function (firstArg) {
+	barMacro.title = function (title, firstArg) {
 		return firstArg + 'bar';
 	};
 


### PR DESCRIPTION
This adds basic macro support as discussed in #695.

It does not completely implement the spec outlined there, specifically:

- The macro can only specify the title using a function in `macroFn.title`. We discussed allowing `macroFn.title` to also be a string, and allowing some form of template language for extracting a title. However, using ES2015 string templates is already pretty easy, so we may just skip this.
- ~~We discussed allowing an array of macro functions.~~

Both the above proposals are found in [this comment](https://github.com/sindresorhus/ava/issues/695#issuecomment-205929738). They both enhance the implementation found in this commit, and would not break the contract. So I don't think there is anything preventing us from shipping this now.