### PR TITLE
Protect against bad argument passed to t.throws.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -84,6 +84,10 @@ x.throws = function (fn, err, msg) {
 			});
 	}
 
+	if (typeof fn !== 'function') {
+		throw new TypeError('t.throws must be called with a function, Promise, or Observable');
+	}
+
 	try {
 		if (typeof err === 'string') {
 			var errMsg = err;
@@ -121,6 +125,10 @@ x.notThrows = function (fn, msg) {
 					throw err;
 				}, msg);
 			});
+	}
+
+	if (typeof fn !== 'function') {
+		throw new TypeError('t.notThrows must be called with a function, Promise, or Observable');
 	}
 
 	try {

--- a/test/assert.js
+++ b/test/assert.js
@@ -285,6 +285,22 @@ test('.throws() returns the rejection reason of promise', function (t) {
 	});
 });
 
+test('.throws should throw if passed a bad value', function (t) {
+	t.plan(1);
+
+	t.throws(function () {
+		assert.throws('not a function');
+	}, {name: 'TypeError', message: /t\.throws must be called with a function, Promise, or Observable/});
+});
+
+test('.notThrows should throw if passed a bad value', function (t) {
+	t.plan(1);
+
+	t.throws(function () {
+		assert.notThrows('not a function');
+	}, {name: 'TypeError', message: /t\.notThrows must be called with a function, Promise, or Observable/});
+});
+
 test('.notThrows()', function (t) {
 	t.doesNotThrow(function () {
 		assert.notThrows(function () {});

--- a/test/test.js
+++ b/test/test.js
@@ -246,6 +246,17 @@ test('handle notThrows with error', function (t) {
 	t.end();
 });
 
+test('fails if a bad value is passed to t.throws', function (t) {
+	var result = ava(function (a) {
+		a.throws('not a function');
+	}).run();
+
+	t.is(result.passed, false);
+	t.ok(result.reason);
+	t.is(result.reason.name, 'TypeError');
+	t.end();
+});
+
 test('handle notThrows without error', function (t) {
 	var result = ava(function (a) {
 		a.notThrows(function () {


### PR DESCRIPTION
If a non-function, non-promise, non-observable argument (i.e. a string)  is passed to `t.throws`, the assertion passes. This obviously isn't what we want.